### PR TITLE
Add language-aware CV link component with browser detection

### DIFF
--- a/src/components/CVLink.tsx
+++ b/src/components/CVLink.tsx
@@ -1,0 +1,44 @@
+import { useEffect, useState } from "react";
+
+interface CVLinkProps {
+  children: React.ReactNode;
+  hash?: string;
+  className?: string;
+}
+
+const SUPPORTED_LANGUAGES = ["en", "es"] as const;
+type SupportedLanguage = (typeof SUPPORTED_LANGUAGES)[number];
+const DEFAULT_LANGUAGE: SupportedLanguage = "en";
+
+function getBrowserLanguage(): SupportedLanguage {
+  if (typeof navigator === "undefined") {
+    return DEFAULT_LANGUAGE;
+  }
+
+  const browserLang = navigator.language.split("-")[0]?.toLowerCase();
+
+  if (
+    browserLang &&
+    SUPPORTED_LANGUAGES.includes(browserLang as SupportedLanguage)
+  ) {
+    return browserLang as SupportedLanguage;
+  }
+
+  return DEFAULT_LANGUAGE;
+}
+
+export default function CVLink({ children, hash, className }: CVLinkProps) {
+  const [lang, setLang] = useState<SupportedLanguage>(DEFAULT_LANGUAGE);
+
+  useEffect(() => {
+    setLang(getBrowserLanguage());
+  }, []);
+
+  const href = `/cv/${lang}/${hash ? `#${hash}` : ""}`;
+
+  return (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  );
+}

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,5 +1,6 @@
 ---
 import type { links } from "@/links";
+import CVLink from "@/components/CVLink";
 
 const currentYear = new Date().getFullYear();
 interface Props {
@@ -22,9 +23,15 @@ interface Props {
       {
         Astro.props.links.map((link) => (
           <li class="list-none">
-            <a href={link.href} class="hover:underline me-4 md:me-6">
-              {link.label}
-            </a>
+            {link.href === "/cv" ? (
+              <CVLink className="hover:underline me-4 md:me-6" client:load>
+                {link.label}
+              </CVLink>
+            ) : (
+              <a href={link.href} class="hover:underline me-4 md:me-6">
+                {link.label}
+              </a>
+            )}
           </li>
         ))
       }

--- a/src/pages/cv/[lang]/index.astro
+++ b/src/pages/cv/[lang]/index.astro
@@ -73,7 +73,7 @@ const { Content } = cvPath;
         })()
       }
     </div>
-    <div class="language-selector text-right mt-2 mr-8 print:hidden">
+    <div class="language-selector fixed top-4 left-4 print:hidden">
       <a href="/cv/en/" class={currentLang === "en" ? "font-bold" : ""}
         >English</a
       > |

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,5 +1,6 @@
 ---
 import AboutMe from "@/components/AboutMe.astro";
+import CVLink from "@/components/CVLink";
 import Experience from "@/components/Experience.astro";
 import Hero from "@/components/Hero.astro";
 import ArrowRightIcon from "@/components/icons/ArrowRightIcon.astro";
@@ -54,7 +55,7 @@ const info = about.data;
         <div
           class="group flex gap-2 items-center justify-center text-orange-500 dark:text-orange-200 transition"
         >
-          <a href="/cv#employment">See full list</a>
+          <CVLink hash="employment" client:load>See full list</CVLink>
           <ArrowRightIcon
             class="size-4 transition group-hover:animate-bounce-right"
           />


### PR DESCRIPTION
## Summary
Introduces a new `CVLink` component that automatically detects the user's browser language and routes them to the appropriate CV version (English or Spanish). This replaces hardcoded CV links throughout the application with intelligent language-aware alternatives.

## Key Changes
- **New Component**: Created `CVLink.tsx` that:
  - Detects browser language on client-side using `navigator.language`
  - Supports English and Spanish with English as fallback
  - Generates dynamic CV URLs in the format `/cv/{language}/{hash}`
  - Accepts optional hash parameter for section anchors

- **Updated Footer**: Modified `Footer.astro` to use `CVLink` for CV navigation link instead of static href

- **Updated Home Page**: Changed "See full list" link in Experience section to use `CVLink` with employment hash anchor

## Implementation Details
- Uses React hooks (`useState`, `useEffect`) to handle browser language detection after hydration, avoiding SSR mismatches
- Safely handles server-side rendering by defaulting to English when `navigator` is unavailable
- Maintains existing styling and className support for seamless integration
- Marked components with `client:load` directive for proper Astro hydration

https://claude.ai/code/session_019fzKB1pKHDUmhSR57qeAGQ