### PR TITLE
Rewrite mapping-db-rows article to focus on Scenario B

### DIFF
--- a/src/content/blog/mapping-db-rows-to-tagged-unions-with-effect-schema.md
+++ b/src/content/blog/mapping-db-rows-to-tagged-unions-with-effect-schema.md
@@ -1,7 +1,7 @@
 ---
 title: Mapping DB Rows to Tagged Unions with Effect Schema
 date: 2026-04-22
-description: How to bridge the gap between flat wide-table database rows and Effect tagged union domain types using Schema.transformOrFail, Match.discriminatorsExhaustive, and Match.tagsExhaustive — with exhaustiveness enforced at compile time.
+description: Database schemas rarely match your domain types. Here's how to safely map a wide table with nullable columns to a discriminated union — with exhaustiveness enforced by the type system.
 tags:
   - typescript
   - effect-ts
@@ -9,44 +9,15 @@ tags:
   - type-safety
 ---
 
-## Context
+## The problem
 
-Database schemas rarely match the shape of an Effect `Schema` one-to-one.
-A common mismatch is a domain tagged union whose persisted form is a flat
-row with per-variant nullable columns. `Schema.decode` rejects that row
-because its `Encoded` type doesn't match, and `Schema.decodeUnknown`
-silently accepts drift between the table and the schema.
+Database schemas rarely match the shape of domain types.
+A common mismatch is a tagged union whose persisted form is a flat wide table with
+per-variant nullable columns. `Schema.decode` rejects that row because
+its `Encoded` type doesn't match, and `Schema.decodeUnknown` silently
+accepts drift between the table and the schema.
 
-There are two levels of answer:
-
-1. If the DB representation per variant is "clean" (separate tables, a
-   view, or a JSON payload column), a plain `Schema.Union` is enough —
-   no transform, no dispatch.
-2. If the DB is a classic wide table with per-variant nullable columns
-   (the realistic case), the manual step collapses to a small
-   `Match.discriminatorsExhaustive` / `Match.tagsExhaustive` block.
-   Exhaustiveness is enforced by the type system, so adding a new
-   variant becomes a compile error rather than a silent skip.
-
-## Scenario A — No transform needed (when possible)
-
-If each row only carries the columns for its own variant, a
-discriminated `Schema.Union` is the row schema *and* the domain schema.
-See `packages/effect/test/Schema/Schema/Union/Union.test.ts:34-77`.
-
-```ts
-import { Schema } from "effect"
-
-const Notification = Schema.Union(
-  Schema.Struct({ _tag: Schema.Literal("Email"), id: Schema.String, address: Schema.String, subject: Schema.String }),
-  Schema.Struct({ _tag: Schema.Literal("Sms"),   id: Schema.String, phone: Schema.String }),
-  Schema.Struct({ _tag: Schema.Literal("Push"),  id: Schema.String, deviceToken: Schema.String, title: Schema.String })
-)
-```
-
-## Scenario B — Wide table, nullable columns (realistic)
-
-Table:
+The wide table pattern looks like this:
 
 ```sql
 notifications(
@@ -57,7 +28,7 @@ notifications(
 )
 ```
 
-Domain:
+And the domain type we want on the TypeScript side:
 
 ```ts
 type Notification =
@@ -66,7 +37,10 @@ type Notification =
   | { _tag: "Push";  id: string; deviceToken: string; title: string }
 ```
 
-### Step 1 — row schema and domain schema
+The solution is a `Schema.transformOrFail` that maps between the two,
+with exhaustiveness for every variant enforced at compile time.
+
+## Step 1 — row schema and domain schema
 
 ```ts
 import { Match, ParseResult, Schema, pipe } from "effect"
@@ -90,7 +64,7 @@ const NotificationDomain = Schema.Union(Email, Sms, Push)
 type NotificationDomain = typeof NotificationDomain.Type
 ```
 
-### Step 2 — lift a nullable cell into a `ParseIssue`
+## Step 2 — lift a nullable cell into a `ParseIssue`
 
 ```ts
 const required =
@@ -101,7 +75,7 @@ const required =
       : ParseResult.succeed(value)
 ```
 
-### Step 3 — decode with `Match.discriminatorsExhaustive`
+## Step 3 — decode with `Match.discriminatorsExhaustive`
 
 `discriminatorsExhaustive("kind")({...})` forces a handler for every
 literal in `kind`. Drop a case → compile error.
@@ -129,7 +103,7 @@ const decodeRow = (row: NotificationRow, ast: ParseResult.ParseIssue["ast"]) => 
 }
 ```
 
-### Step 4 — encode with `Match.tagsExhaustive`
+## Step 4 — encode with `Match.tagsExhaustive`
 
 On the domain side `_tag` is the discriminator, so use `tagsExhaustive`.
 Again: add a fourth tag to the union → compile error here.
@@ -150,7 +124,7 @@ const encodeDomain = Match.type<NotificationDomain>().pipe(
 )
 ```
 
-### Step 5 — wire them with `Schema.transformOrFail`
+## Step 5 — wire them with `Schema.transformOrFail`
 
 ```ts
 const Notification = Schema.transformOrFail(NotificationRow, NotificationDomain, {
@@ -165,16 +139,18 @@ const Notification = Schema.transformOrFail(NotificationRow, NotificationDomain,
 
 ## Why this beats `decodeUnknown`
 
-- `Match.discriminatorsExhaustive` and `Match.tagsExhaustive` both
-  reject non-exhaustive handlers at compile time — the same guarantee a
+- The exhaustive match helpers reject non-exhaustive handlers at compile time — the same guarantee a
   `switch` gives with `Match.exhaustive`, but declarative.
 - The row schema is itself a typed `Schema`. Rename a column → DB
   queries and the transform both fail to type-check.
 - Each variant mapping is one line once null-lifting is factored out.
 
-## Scenario C — Escape hatches
+## Escape hatches
+
+Not every project ends up with wide tables. Two common alternatives:
 
 - **JSON payload column.** `kind text` + `payload jsonb`; decode with
-  `Schema.parseJson(Schema.Union(Email, Sms, Push))`. No transform
-  needed.
-- **Per-variant tables + view.** The view emits Scenario A rows.
+  `Schema.parseJson(Schema.Union(Email, Sms, Push))`. No transform needed.
+- **Per-variant tables + view.** The view emits clean rows where each row only
+  carries the columns for its own variant, which a plain `Schema.Union` handles
+  without any transform.

--- a/src/content/blog/mapping-db-rows-to-tagged-unions-with-effect-schema.md
+++ b/src/content/blog/mapping-db-rows-to-tagged-unions-with-effect-schema.md
@@ -43,7 +43,7 @@ with exhaustiveness for every variant enforced at compile time.
 ## Step 1 — row schema and domain schema
 
 ```ts
-import { Match, ParseResult, Schema, pipe } from "effect"
+import { Match, ParseResult, Schema, SchemaAST, pipe } from "effect"
 
 const NotificationRow = Schema.Struct({
   id: Schema.String,
@@ -66,9 +66,14 @@ type NotificationDomain = typeof NotificationDomain.Type
 
 ## Step 2 — lift a nullable cell into a `ParseIssue`
 
+`ParseResult.Type` takes an `AST.AST` as its first argument — that's the expected
+type description used in error messages. The `ast` the `decode` callback
+receives from `transformOrFail` is `SchemaAST.Transformation`, which is
+a member of that union.
+
 ```ts
 const required =
-  <T>(ast: ParseResult.ParseIssue["ast"], row: NotificationRow) =>
+  <T>(ast: SchemaAST.AST, row: NotificationRow) =>
   (value: T | null, column: string) =>
     value === null
       ? ParseResult.fail(new ParseResult.Type(ast, row, `${column} required when kind=${row.kind}`))
@@ -81,7 +86,7 @@ const required =
 literal in `kind`. Drop a case → compile error.
 
 ```ts
-const decodeRow = (row: NotificationRow, ast: ParseResult.ParseIssue["ast"]) => {
+const decodeRow = (row: NotificationRow, ast: SchemaAST.Transformation) => {
   const need = required(ast, row)
   return pipe(
     Match.type<NotificationRow>(),
@@ -154,3 +159,96 @@ Not every project ends up with wide tables. Two common alternatives:
 - **Per-variant tables + view.** The view emits clean rows where each row only
   carries the columns for its own variant, which a plain `Schema.Union` handles
   without any transform.
+
+---
+
+<div class="not-prose mt-10">
+  <details class="rounded-xl border border-gray-200 dark:border-gray-800 overflow-hidden">
+    <summary class="cursor-pointer select-none px-4 py-3 text-sm font-semibold text-gray-700 dark:text-gray-300 bg-gray-50 dark:bg-gray-800/50 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors">
+      Complete example
+    </summary>
+    <div class="relative">
+      <button id="copy-complete" class="absolute top-3 right-3 z-10 px-2.5 py-1 text-xs font-medium rounded-md bg-gray-700 text-gray-200 hover:bg-gray-600 transition-colors">Copy</button>
+      <pre id="complete-code" class="m-0 rounded-none text-sm p-6 bg-gray-900 dark:bg-gray-950 text-gray-100 overflow-x-auto leading-relaxed"><code>import { Match, ParseResult, Schema, SchemaAST, pipe } from "effect"
+
+const NotificationRow = Schema.Struct({
+  id: Schema.String,
+  kind: Schema.Literal("Email", "Sms", "Push"),
+  email_address:     Schema.NullOr(Schema.String),
+  email_subject:     Schema.NullOr(Schema.String),
+  sms_phone:         Schema.NullOr(Schema.String),
+  push_device_token: Schema.NullOr(Schema.String),
+  push_title:        Schema.NullOr(Schema.String)
+})
+type NotificationRow = typeof NotificationRow.Type
+
+const Email = Schema.TaggedStruct("Email", { id: Schema.String, address: Schema.String, subject: Schema.String })
+const Sms   = Schema.TaggedStruct("Sms",   { id: Schema.String, phone: Schema.String })
+const Push  = Schema.TaggedStruct("Push",  { id: Schema.String, deviceToken: Schema.String, title: Schema.String })
+
+const NotificationDomain = Schema.Union(Email, Sms, Push)
+type NotificationDomain = typeof NotificationDomain.Type
+
+const required =
+  &lt;T&gt;(ast: SchemaAST.AST, row: NotificationRow) =&gt;
+  (value: T | null, column: string) =&gt;
+    value === null
+      ? ParseResult.fail(new ParseResult.Type(ast, row, `${column} required when kind=${row.kind}`))
+      : ParseResult.succeed(value)
+
+const decodeRow = (row: NotificationRow, ast: SchemaAST.Transformation) =&gt; {
+  const need = required(ast, row)
+  return pipe(
+    Match.type&lt;NotificationRow&gt;(),
+    Match.discriminatorsExhaustive("kind")({
+      Email: (r) =&gt;
+        ParseResult.all([need(r.email_address, "email_address"), need(r.email_subject, "email_subject")]).pipe(
+          ParseResult.map(([address, subject]) =&gt; Email.make({ id: r.id, address, subject }))
+        ),
+      Sms: (r) =&gt;
+        need(r.sms_phone, "sms_phone").pipe(
+          ParseResult.map((phone) =&gt; Sms.make({ id: r.id, phone }))
+        ),
+      Push: (r) =&gt;
+        ParseResult.all([need(r.push_device_token, "push_device_token"), need(r.push_title, "push_title")]).pipe(
+          ParseResult.map(([deviceToken, title]) =&gt; Push.make({ id: r.id, deviceToken, title }))
+        )
+    })
+  )(row)
+}
+
+const nulls = {
+  email_address: null, email_subject: null,
+  sms_phone: null,
+  push_device_token: null, push_title: null
+} as const
+
+const encodeDomain = Match.type&lt;NotificationDomain&gt;().pipe(
+  Match.tagsExhaustive({
+    Email: (n) =&gt; ({ ...nulls, id: n.id, kind: "Email" as const, email_address: n.address, email_subject: n.subject }),
+    Sms:   (n) =&gt; ({ ...nulls, id: n.id, kind: "Sms"   as const, sms_phone: n.phone }),
+    Push:  (n) =&gt; ({ ...nulls, id: n.id, kind: "Push"  as const, push_device_token: n.deviceToken, push_title: n.title })
+  })
+)
+
+const Notification = Schema.transformOrFail(NotificationRow, NotificationDomain, {
+  decode: (row, _opts, ast) =&gt; decodeRow(row, ast),
+  encode: (domain) =&gt; ParseResult.succeed(encodeDomain(domain))
+})</code></pre>
+    </div>
+  </details>
+</div>
+
+<script>
+  (function () {
+    var btn = document.getElementById("copy-complete");
+    if (!btn) return;
+    btn.addEventListener("click", function () {
+      var pre = document.getElementById("complete-code");
+      navigator.clipboard.writeText(pre.innerText).then(function () {
+        btn.textContent = "Copied!";
+        setTimeout(function () { btn.textContent = "Copy"; }, 2000);
+      });
+    });
+  })();
+</script>


### PR DESCRIPTION
Remove Scenario A (clean rows, no transform needed) as it doesn't
contribute to the core topic. Restructure the content so the wide-table
problem is introduced directly as the context, without the detour.
Rewrite the description to sound less like generated API docs.
Move Scenario C escape hatches to a closing section with brief prose.