### PR TITLE
Rewrite mapping-db-rows article to focus on Scenario B

### DIFF
--- a/src/content/blog/mapping-db-rows-to-tagged-unions-with-effect-schema.md
+++ b/src/content/blog/mapping-db-rows-to-tagged-unions-with-effect-schema.md
@@ -1,7 +1,7 @@
 ---
 title: Mapping DB Rows to Tagged Unions with Effect Schema
 date: 2026-04-22
-description: How to bridge the gap between flat wide-table database rows and Effect tagged union domain types using Schema.transformOrFail, Match.discriminatorsExhaustive, and Match.tagsExhaustive — with exhaustiveness enforced at compile time.
+description: Database schemas rarely match your domain types. Here's how to safely map a wide table with nullable columns to a discriminated union — with exhaustiveness enforced by the type system.
 tags:
   - typescript
   - effect-ts
@@ -9,44 +9,15 @@ tags:
   - type-safety
 ---
 
-## Context
+## The problem
 
-Database schemas rarely match the shape of an Effect `Schema` one-to-one.
-A common mismatch is a domain tagged union whose persisted form is a flat
-row with per-variant nullable columns. `Schema.decode` rejects that row
-because its `Encoded` type doesn't match, and `Schema.decodeUnknown`
-silently accepts drift between the table and the schema.
+Database schemas rarely match the shape of domain types.
+A common mismatch is a tagged union whose persisted form is a flat wide table with
+per-variant nullable columns. `Schema.decode` rejects that row because
+its `Encoded` type doesn't match, and `Schema.decodeUnknown` silently
+accepts drift between the table and the schema.
 
-There are two levels of answer:
-
-1. If the DB representation per variant is "clean" (separate tables, a
-   view, or a JSON payload column), a plain `Schema.Union` is enough —
-   no transform, no dispatch.
-2. If the DB is a classic wide table with per-variant nullable columns
-   (the realistic case), the manual step collapses to a small
-   `Match.discriminatorsExhaustive` / `Match.tagsExhaustive` block.
-   Exhaustiveness is enforced by the type system, so adding a new
-   variant becomes a compile error rather than a silent skip.
-
-## Scenario A — No transform needed (when possible)
-
-If each row only carries the columns for its own variant, a
-discriminated `Schema.Union` is the row schema *and* the domain schema.
-See `packages/effect/test/Schema/Schema/Union/Union.test.ts:34-77`.
-
-```ts
-import { Schema } from "effect"
-
-const Notification = Schema.Union(
-  Schema.Struct({ _tag: Schema.Literal("Email"), id: Schema.String, address: Schema.String, subject: Schema.String }),
-  Schema.Struct({ _tag: Schema.Literal("Sms"),   id: Schema.String, phone: Schema.String }),
-  Schema.Struct({ _tag: Schema.Literal("Push"),  id: Schema.String, deviceToken: Schema.String, title: Schema.String })
-)
-```
-
-## Scenario B — Wide table, nullable columns (realistic)
-
-Table:
+The wide table pattern looks like this:
 
 ```sql
 notifications(
@@ -57,7 +28,7 @@ notifications(
 )
 ```
 
-Domain:
+And the domain type we want on the TypeScript side:
 
 ```ts
 type Notification =
@@ -66,7 +37,10 @@ type Notification =
   | { _tag: "Push";  id: string; deviceToken: string; title: string }
 ```
 
-### Step 1 — row schema and domain schema
+The solution is a `Schema.transformOrFail` that maps between the two,
+with exhaustiveness for every variant enforced at compile time.
+
+## Step 1 — row schema and domain schema
 
 ```ts
 import { Match, ParseResult, Schema, pipe } from "effect"
@@ -90,7 +64,7 @@ const NotificationDomain = Schema.Union(Email, Sms, Push)
 type NotificationDomain = typeof NotificationDomain.Type
 ```
 
-### Step 2 — lift a nullable cell into a `ParseIssue`
+## Step 2 — lift a nullable cell into a `ParseIssue`
 
 ```ts
 const required =
@@ -101,7 +75,7 @@ const required =
       : ParseResult.succeed(value)
 ```
 
-### Step 3 — decode with `Match.discriminatorsExhaustive`
+## Step 3 — decode with `Match.discriminatorsExhaustive`
 
 `discriminatorsExhaustive("kind")({...})` forces a handler for every
 literal in `kind`. Drop a case → compile error.
@@ -129,7 +103,7 @@ const decodeRow = (row: NotificationRow, ast: ParseResult.ParseIssue["ast"]) => 
 }
 ```
 
-### Step 4 — encode with `Match.tagsExhaustive`
+## Step 4 — encode with `Match.tagsExhaustive`
 
 On the domain side `_tag` is the discriminator, so use `tagsExhaustive`.
 Again: add a fourth tag to the union → compile error here.
@@ -150,7 +124,7 @@ const encodeDomain = Match.type<NotificationDomain>().pipe(
 )
 ```
 
-### Step 5 — wire them with `Schema.transformOrFail`
+## Step 5 — wire them with `Schema.transformOrFail`
 
 ```ts
 const Notification = Schema.transformOrFail(NotificationRow, NotificationDomain, {
@@ -165,16 +139,18 @@ const Notification = Schema.transformOrFail(NotificationRow, NotificationDomain,
 
 ## Why this beats `decodeUnknown`
 
-- `Match.discriminatorsExhaustive` and `Match.tagsExhaustive` both
-  reject non-exhaustive handlers at compile time — the same guarantee a
+- The exhaustive match helpers reject non-exhaustive handlers at compile time — the same guarantee a
   `switch` gives with `Match.exhaustive`, but declarative.
 - The row schema is itself a typed `Schema`. Rename a column → DB
   queries and the transform both fail to type-check.
 - Each variant mapping is one line once null-lifting is factored out.
 
-## Scenario C — Escape hatches
+## Escape hatches
+
+Not every project ends up with wide tables. Two common alternatives:
 
 - **JSON payload column.** `kind text` + `payload jsonb`; decode with
-  `Schema.parseJson(Schema.Union(Email, Sms, Push))`. No transform
-  needed.
-- **Per-variant tables + view.** The view emits Scenario A rows.
+  `Schema.parseJson(Schema.Union(Email, Sms, Push))`. No transform needed.
+- **Per-variant tables + view.** The view emits clean rows where each row only
+  carries the columns for its own variant, which a plain `Schema.Union` handles
+  without any transform.

--- a/src/content/blog/mapping-db-rows-to-tagged-unions-with-effect-schema.md
+++ b/src/content/blog/mapping-db-rows-to-tagged-unions-with-effect-schema.md
@@ -43,7 +43,7 @@ with exhaustiveness for every variant enforced at compile time.
 ## Step 1 — row schema and domain schema
 
 ```ts
-import { Match, ParseResult, Schema, pipe } from "effect"
+import { Match, ParseResult, Schema, SchemaAST, pipe } from "effect"
 
 const NotificationRow = Schema.Struct({
   id: Schema.String,
@@ -66,9 +66,14 @@ type NotificationDomain = typeof NotificationDomain.Type
 
 ## Step 2 — lift a nullable cell into a `ParseIssue`
 
+`ParseResult.Type` takes an `AST.AST` as its first argument — that's the expected
+type description used in error messages. The `ast` the `decode` callback
+receives from `transformOrFail` is `SchemaAST.Transformation`, which is
+a member of that union.
+
 ```ts
 const required =
-  <T>(ast: ParseResult.ParseIssue["ast"], row: NotificationRow) =>
+  <T>(ast: SchemaAST.AST, row: NotificationRow) =>
   (value: T | null, column: string) =>
     value === null
       ? ParseResult.fail(new ParseResult.Type(ast, row, `${column} required when kind=${row.kind}`))
@@ -81,7 +86,7 @@ const required =
 literal in `kind`. Drop a case → compile error.
 
 ```ts
-const decodeRow = (row: NotificationRow, ast: ParseResult.ParseIssue["ast"]) => {
+const decodeRow = (row: NotificationRow, ast: SchemaAST.Transformation) => {
   const need = required(ast, row)
   return pipe(
     Match.type<NotificationRow>(),
@@ -154,3 +159,96 @@ Not every project ends up with wide tables. Two common alternatives:
 - **Per-variant tables + view.** The view emits clean rows where each row only
   carries the columns for its own variant, which a plain `Schema.Union` handles
   without any transform.
+
+---
+
+<div class="not-prose mt-10">
+  <details class="rounded-xl border border-gray-200 dark:border-gray-800 overflow-hidden">
+    <summary class="cursor-pointer select-none px-4 py-3 text-sm font-semibold text-gray-700 dark:text-gray-300 bg-gray-50 dark:bg-gray-800/50 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors">
+      Complete example
+    </summary>
+    <div class="relative">
+      <button id="copy-complete" class="absolute top-3 right-3 z-10 px-2.5 py-1 text-xs font-medium rounded-md bg-gray-700 text-gray-200 hover:bg-gray-600 transition-colors">Copy</button>
+      <pre id="complete-code" class="m-0 rounded-none text-sm p-6 bg-gray-900 dark:bg-gray-950 text-gray-100 overflow-x-auto leading-relaxed"><code>import { Match, ParseResult, Schema, SchemaAST, pipe } from "effect"
+
+const NotificationRow = Schema.Struct({
+  id: Schema.String,
+  kind: Schema.Literal("Email", "Sms", "Push"),
+  email_address:     Schema.NullOr(Schema.String),
+  email_subject:     Schema.NullOr(Schema.String),
+  sms_phone:         Schema.NullOr(Schema.String),
+  push_device_token: Schema.NullOr(Schema.String),
+  push_title:        Schema.NullOr(Schema.String)
+})
+type NotificationRow = typeof NotificationRow.Type
+
+const Email = Schema.TaggedStruct("Email", { id: Schema.String, address: Schema.String, subject: Schema.String })
+const Sms   = Schema.TaggedStruct("Sms",   { id: Schema.String, phone: Schema.String })
+const Push  = Schema.TaggedStruct("Push",  { id: Schema.String, deviceToken: Schema.String, title: Schema.String })
+
+const NotificationDomain = Schema.Union(Email, Sms, Push)
+type NotificationDomain = typeof NotificationDomain.Type
+
+const required =
+  &lt;T&gt;(ast: SchemaAST.AST, row: NotificationRow) =&gt;
+  (value: T | null, column: string) =&gt;
+    value === null
+      ? ParseResult.fail(new ParseResult.Type(ast, row, `${column} required when kind=${row.kind}`))
+      : ParseResult.succeed(value)
+
+const decodeRow = (row: NotificationRow, ast: SchemaAST.Transformation) =&gt; {
+  const need = required(ast, row)
+  return pipe(
+    Match.type&lt;NotificationRow&gt;(),
+    Match.discriminatorsExhaustive("kind")({
+      Email: (r) =&gt;
+        ParseResult.all([need(r.email_address, "email_address"), need(r.email_subject, "email_subject")]).pipe(
+          ParseResult.map(([address, subject]) =&gt; Email.make({ id: r.id, address, subject }))
+        ),
+      Sms: (r) =&gt;
+        need(r.sms_phone, "sms_phone").pipe(
+          ParseResult.map((phone) =&gt; Sms.make({ id: r.id, phone }))
+        ),
+      Push: (r) =&gt;
+        ParseResult.all([need(r.push_device_token, "push_device_token"), need(r.push_title, "push_title")]).pipe(
+          ParseResult.map(([deviceToken, title]) =&gt; Push.make({ id: r.id, deviceToken, title }))
+        )
+    })
+  )(row)
+}
+
+const nulls = {
+  email_address: null, email_subject: null,
+  sms_phone: null,
+  push_device_token: null, push_title: null
+} as const
+
+const encodeDomain = Match.type&lt;NotificationDomain&gt;().pipe(
+  Match.tagsExhaustive({
+    Email: (n) =&gt; ({ ...nulls, id: n.id, kind: "Email" as const, email_address: n.address, email_subject: n.subject }),
+    Sms:   (n) =&gt; ({ ...nulls, id: n.id, kind: "Sms"   as const, sms_phone: n.phone }),
+    Push:  (n) =&gt; ({ ...nulls, id: n.id, kind: "Push"  as const, push_device_token: n.deviceToken, push_title: n.title })
+  })
+)
+
+const Notification = Schema.transformOrFail(NotificationRow, NotificationDomain, {
+  decode: (row, _opts, ast) =&gt; decodeRow(row, ast),
+  encode: (domain) =&gt; ParseResult.succeed(encodeDomain(domain))
+})</code></pre>
+    </div>
+  </details>
+</div>
+
+<script>
+  (function () {
+    var btn = document.getElementById("copy-complete");
+    if (!btn) return;
+    btn.addEventListener("click", function () {
+      var pre = document.getElementById("complete-code");
+      navigator.clipboard.writeText(pre.innerText).then(function () {
+        btn.textContent = "Copied!";
+        setTimeout(function () { btn.textContent = "Copy"; }, 2000);
+      });
+    });
+  })();
+</script>

--- a/src/content/blog/mapping-db-rows-to-tagged-unions-with-effect-schema.md
+++ b/src/content/blog/mapping-db-rows-to-tagged-unions-with-effect-schema.md
@@ -178,7 +178,18 @@ Not every project ends up with wide tables. Two common alternatives:
     </summary>
     <div class="relative">
       <button id="copy-complete" class="absolute top-3 right-3 z-10 px-2.5 py-1 text-xs font-medium rounded-md bg-gray-700 text-gray-200 hover:bg-gray-600 transition-colors">Copy</button>
-      <pre id="complete-code" class="m-0 rounded-none text-sm p-6 bg-gray-900 dark:bg-gray-950 text-gray-100 overflow-x-auto leading-relaxed"><code>import { Effect, Match, ParseResult, Schema, SchemaAST } from "effect"
+      <pre id="complete-code" class="m-0 rounded-none text-sm p-6 bg-gray-900 dark:bg-gray-950 text-gray-100 overflow-x-auto leading-relaxed"></pre>
+    </div>
+  </details>
+</div>
+
+<script>
+  (function () {
+    var pre = document.getElementById("complete-code");
+    var btn = document.getElementById("copy-complete");
+    if (!pre || !btn) return;
+
+    pre.textContent = `import { Effect, Match, ParseResult, Schema, SchemaAST } from "effect"
 
 const NotificationRow = Schema.Struct({
   id: Schema.String,
@@ -199,29 +210,29 @@ const NotificationDomain = Schema.Union(Email, Sms, Push)
 type NotificationDomain = typeof NotificationDomain.Type
 
 const required =
-  &lt;T&gt;(ast: SchemaAST.AST, row: NotificationRow) =&gt;
-  (value: T | null, column: string) =&gt;
+  <T>(ast: SchemaAST.AST, row: NotificationRow) =>
+  (value: T | null, column: string) =>
     value === null
-      ? ParseResult.fail(new ParseResult.Type(ast, row, `${column} required when kind=${row.kind}`))
+      ? ParseResult.fail(new ParseResult.Type(ast, row, \`\${column} required when kind=\${row.kind}\`))
       : ParseResult.succeed(value)
 
 const decodeRow = (
   row: NotificationRow,
   ast: SchemaAST.Transformation
-): Effect.Effect&lt;NotificationDomain, ParseResult.ParseIssue&gt; =&gt; {
+): Effect.Effect<NotificationDomain, ParseResult.ParseIssue> => {
   const need = required(ast, row)
   switch (row.kind) {
     case "Email":
       return Effect.all([need(row.email_address, "email_address"), need(row.email_subject, "email_subject")]).pipe(
-        Effect.map(([address, subject]) =&gt; Email.make({ id: row.id, address, subject }))
+        Effect.map(([address, subject]) => Email.make({ id: row.id, address, subject }))
       )
     case "Sms":
       return need(row.sms_phone, "sms_phone").pipe(
-        Effect.map((phone) =&gt; Sms.make({ id: row.id, phone }))
+        Effect.map((phone) => Sms.make({ id: row.id, phone }))
       )
     case "Push":
       return Effect.all([need(row.push_device_token, "push_device_token"), need(row.push_title, "push_title")]).pipe(
-        Effect.map(([deviceToken, title]) =&gt; Push.make({ id: row.id, deviceToken, title }))
+        Effect.map(([deviceToken, title]) => Push.make({ id: row.id, deviceToken, title }))
       )
   }
 }
@@ -232,29 +243,21 @@ const nulls = {
   push_device_token: null, push_title: null
 } as const
 
-const encodeDomain = Match.type&lt;NotificationDomain&gt;().pipe(
+const encodeDomain = Match.type<NotificationDomain>().pipe(
   Match.tagsExhaustive({
-    Email: (n) =&gt; ({ ...nulls, id: n.id, kind: "Email" as const, email_address: n.address, email_subject: n.subject }),
-    Sms:   (n) =&gt; ({ ...nulls, id: n.id, kind: "Sms"   as const, sms_phone: n.phone }),
-    Push:  (n) =&gt; ({ ...nulls, id: n.id, kind: "Push"  as const, push_device_token: n.deviceToken, push_title: n.title })
+    Email: (n) => ({ ...nulls, id: n.id, kind: "Email" as const, email_address: n.address, email_subject: n.subject }),
+    Sms:   (n) => ({ ...nulls, id: n.id, kind: "Sms"   as const, sms_phone: n.phone }),
+    Push:  (n) => ({ ...nulls, id: n.id, kind: "Push"  as const, push_device_token: n.deviceToken, push_title: n.title })
   })
 )
 
 const Notification = Schema.transformOrFail(NotificationRow, NotificationDomain, {
-  decode: (row, _opts, ast) =&gt; decodeRow(row, ast),
-  encode: (domain) =&gt; ParseResult.succeed(encodeDomain(domain))
-})</code></pre>
-    </div>
-  </details>
-</div>
+  decode: (row, _opts, ast) => decodeRow(row, ast),
+  encode: (domain) => ParseResult.succeed(encodeDomain(domain))
+})`;
 
-<script>
-  (function () {
-    var btn = document.getElementById("copy-complete");
-    if (!btn) return;
     btn.addEventListener("click", function () {
-      var pre = document.getElementById("complete-code");
-      navigator.clipboard.writeText(pre.innerText).then(function () {
+      navigator.clipboard.writeText(pre.textContent).then(function () {
         btn.textContent = "Copied!";
         setTimeout(function () { btn.textContent = "Copy"; }, 2000);
       });

--- a/src/content/blog/mapping-db-rows-to-tagged-unions-with-effect-schema.md
+++ b/src/content/blog/mapping-db-rows-to-tagged-unions-with-effect-schema.md
@@ -38,12 +38,12 @@ type Notification =
 ```
 
 The solution is a `Schema.transformOrFail` that maps between the two,
-with exhaustiveness for every variant enforced at compile time.
+with exhaustiveness enforced at compile time in both directions.
 
 ## Step 1 — row schema and domain schema
 
 ```ts
-import { Match, ParseResult, Schema, SchemaAST, pipe } from "effect"
+import { Effect, Match, ParseResult, Schema, SchemaAST } from "effect"
 
 const NotificationRow = Schema.Struct({
   id: Schema.String,
@@ -66,7 +66,7 @@ type NotificationDomain = typeof NotificationDomain.Type
 
 ## Step 2 — lift a nullable cell into a `ParseIssue`
 
-`ParseResult.Type` takes an `AST.AST` as its first argument — that's the expected
+`ParseResult.Type` takes a `SchemaAST.AST` as its first argument — the expected
 type description used in error messages. The `ast` the `decode` callback
 receives from `transformOrFail` is `SchemaAST.Transformation`, which is
 a member of that union.
@@ -80,38 +80,45 @@ const required =
       : ParseResult.succeed(value)
 ```
 
-## Step 3 — decode with `Match.discriminatorsExhaustive`
+## Step 3 — decode with an exhaustive switch
 
-`discriminatorsExhaustive("kind")({...})` forces a handler for every
-literal in `kind`. Drop a case → compile error.
+`NotificationRow` is a flat struct, not a discriminated union type, so
+`Match.discriminatorsExhaustive` doesn't apply here — it needs a union where
+each member carries a distinct literal. A `switch` on `row.kind` with an
+explicit return type is the right tool: TypeScript narrows the `kind` field in
+each branch, and if you later add a new literal to `Schema.Literal(...)` without
+adding a case, the compiler errors because the function might not return.
 
 ```ts
-const decodeRow = (row: NotificationRow, ast: SchemaAST.Transformation) => {
+const decodeRow = (
+  row: NotificationRow,
+  ast: SchemaAST.Transformation
+): Effect.Effect<NotificationDomain, ParseResult.ParseIssue> => {
   const need = required(ast, row)
-  return pipe(
-    Match.type<NotificationRow>(),
-    Match.discriminatorsExhaustive("kind")({
-      Email: (r) =>
-        ParseResult.all([need(r.email_address, "email_address"), need(r.email_subject, "email_subject")]).pipe(
-          ParseResult.map(([address, subject]) => Email.make({ id: r.id, address, subject }))
-        ),
-      Sms: (r) =>
-        need(r.sms_phone, "sms_phone").pipe(
-          ParseResult.map((phone) => Sms.make({ id: r.id, phone }))
-        ),
-      Push: (r) =>
-        ParseResult.all([need(r.push_device_token, "push_device_token"), need(r.push_title, "push_title")]).pipe(
-          ParseResult.map(([deviceToken, title]) => Push.make({ id: r.id, deviceToken, title }))
-        )
-    })
-  )(row)
+  switch (row.kind) {
+    case "Email":
+      return Effect.all([need(row.email_address, "email_address"), need(row.email_subject, "email_subject")]).pipe(
+        Effect.map(([address, subject]) => Email.make({ id: row.id, address, subject }))
+      )
+    case "Sms":
+      return need(row.sms_phone, "sms_phone").pipe(
+        Effect.map((phone) => Sms.make({ id: row.id, phone }))
+      )
+    case "Push":
+      return Effect.all([need(row.push_device_token, "push_device_token"), need(row.push_title, "push_title")]).pipe(
+        Effect.map(([deviceToken, title]) => Push.make({ id: row.id, deviceToken, title }))
+      )
+  }
 }
 ```
 
 ## Step 4 — encode with `Match.tagsExhaustive`
 
-On the domain side `_tag` is the discriminator, so use `tagsExhaustive`.
-Again: add a fourth tag to the union → compile error here.
+For the encode direction the situation is different: `NotificationDomain` is a
+proper tagged union (`Schema.Union` of `TaggedStruct` variants), so
+`Match.tagsExhaustive` works correctly here. Each handler receives a
+properly-narrowed type, and adding a fourth variant to the union becomes a
+compile error.
 
 ```ts
 const nulls = {
@@ -144,11 +151,13 @@ const Notification = Schema.transformOrFail(NotificationRow, NotificationDomain,
 
 ## Why this beats `decodeUnknown`
 
-- The exhaustive match helpers reject non-exhaustive handlers at compile time — the same guarantee a
-  `switch` gives with `Match.exhaustive`, but declarative.
 - The row schema is itself a typed `Schema`. Rename a column → DB
   queries and the transform both fail to type-check.
-- Each variant mapping is one line once null-lifting is factored out.
+- The explicit return type on `decodeRow` gives exhaustiveness: add a new
+  literal to `Schema.Literal` and forget the switch case → compile error.
+- `Match.tagsExhaustive` on the encode side gives the same guarantee for
+  the domain → row direction, because `NotificationDomain` is a proper union.
+- Each variant mapping is concise once null-lifting is factored out.
 
 ## Escape hatches
 
@@ -169,7 +178,7 @@ Not every project ends up with wide tables. Two common alternatives:
     </summary>
     <div class="relative">
       <button id="copy-complete" class="absolute top-3 right-3 z-10 px-2.5 py-1 text-xs font-medium rounded-md bg-gray-700 text-gray-200 hover:bg-gray-600 transition-colors">Copy</button>
-      <pre id="complete-code" class="m-0 rounded-none text-sm p-6 bg-gray-900 dark:bg-gray-950 text-gray-100 overflow-x-auto leading-relaxed"><code>import { Match, ParseResult, Schema, SchemaAST, pipe } from "effect"
+      <pre id="complete-code" class="m-0 rounded-none text-sm p-6 bg-gray-900 dark:bg-gray-950 text-gray-100 overflow-x-auto leading-relaxed"><code>import { Effect, Match, ParseResult, Schema, SchemaAST } from "effect"
 
 const NotificationRow = Schema.Struct({
   id: Schema.String,
@@ -196,25 +205,25 @@ const required =
       ? ParseResult.fail(new ParseResult.Type(ast, row, `${column} required when kind=${row.kind}`))
       : ParseResult.succeed(value)
 
-const decodeRow = (row: NotificationRow, ast: SchemaAST.Transformation) =&gt; {
+const decodeRow = (
+  row: NotificationRow,
+  ast: SchemaAST.Transformation
+): Effect.Effect&lt;NotificationDomain, ParseResult.ParseIssue&gt; =&gt; {
   const need = required(ast, row)
-  return pipe(
-    Match.type&lt;NotificationRow&gt;(),
-    Match.discriminatorsExhaustive("kind")({
-      Email: (r) =&gt;
-        ParseResult.all([need(r.email_address, "email_address"), need(r.email_subject, "email_subject")]).pipe(
-          ParseResult.map(([address, subject]) =&gt; Email.make({ id: r.id, address, subject }))
-        ),
-      Sms: (r) =&gt;
-        need(r.sms_phone, "sms_phone").pipe(
-          ParseResult.map((phone) =&gt; Sms.make({ id: r.id, phone }))
-        ),
-      Push: (r) =&gt;
-        ParseResult.all([need(r.push_device_token, "push_device_token"), need(r.push_title, "push_title")]).pipe(
-          ParseResult.map(([deviceToken, title]) =&gt; Push.make({ id: r.id, deviceToken, title }))
-        )
-    })
-  )(row)
+  switch (row.kind) {
+    case "Email":
+      return Effect.all([need(row.email_address, "email_address"), need(row.email_subject, "email_subject")]).pipe(
+        Effect.map(([address, subject]) =&gt; Email.make({ id: row.id, address, subject }))
+      )
+    case "Sms":
+      return need(row.sms_phone, "sms_phone").pipe(
+        Effect.map((phone) =&gt; Sms.make({ id: row.id, phone }))
+      )
+    case "Push":
+      return Effect.all([need(row.push_device_token, "push_device_token"), need(row.push_title, "push_title")]).pipe(
+        Effect.map(([deviceToken, title]) =&gt; Push.make({ id: row.id, deviceToken, title }))
+      )
+  }
 }
 
 const nulls = {


### PR DESCRIPTION
## Summary

- Removes Scenario A (clean rows / no transform needed) — it was a detour that didn't contribute to the core topic
- Reframes the intro as "The problem" and leads directly into the wide-table case
- Rewrites the frontmatter description to be a plain sentence rather than an API name dump
- Fixes two correctness bugs in the code:
  - `ParseResult.ParseIssue["ast"]` → `SchemaAST.AST` (not all `ParseIssue` union members have `ast`)
  - `Match.discriminatorsExhaustive` → `switch` on `row.kind` with an explicit return type (`NotificationRow` is a flat struct, not a discriminated union, so `discriminatorsExhaustive` typed every handler param as `never`)
  - `ParseResult.all` → `Effect.all` (`ParseResult.all` does not exist)
- Keeps `Match.tagsExhaustive` on the encode side, where `NotificationDomain` is a proper tagged union
- Adds a collapsible "Complete example" block at the bottom with a copy button; code is injected via `textContent` so `<`, `>`, `=>` and quotes copy as-is without HTML entity mangling

## Test plan

- [ ] `pnpm run check` passes (0 errors)
- [ ] `pnpm run build` completes successfully
- [ ] Blog post renders correctly and the collapsible block expands
- [ ] Copy button copies valid TypeScript (check `<T>`, `=>`, and the template literal)

---
_Generated by [Claude Code](https://claude.ai/code/session_01G7xjzBKfg4TL7hrMwZdd6r)_