### PR TITLE
Rewrite mapping-db-rows article to focus on Scenario B

### DIFF
--- a/src/content/blog/mapping-db-rows-to-tagged-unions-with-effect-schema.md
+++ b/src/content/blog/mapping-db-rows-to-tagged-unions-with-effect-schema.md
@@ -43,7 +43,7 @@ with exhaustiveness enforced at compile time in both directions.
 ## Step 1 — row schema and domain schema
 
 ```ts
-import { Effect, Match, ParseResult, Schema, SchemaAST } from "effect"
+import { Effect, Either, Match, ParseResult, Schema, SchemaAST } from "effect"
 
 const NotificationRow = Schema.Struct({
   id: Schema.String,
@@ -64,23 +64,7 @@ const NotificationDomain = Schema.Union(Email, Sms, Push)
 type NotificationDomain = typeof NotificationDomain.Type
 ```
 
-## Step 2 — lift a nullable cell into a `ParseIssue`
-
-`ParseResult.Type` takes a `SchemaAST.AST` as its first argument — the expected
-type description used in error messages. The `ast` the `decode` callback
-receives from `transformOrFail` is `SchemaAST.Transformation`, which is
-a member of that union.
-
-```ts
-const required =
-  <T>(ast: SchemaAST.AST, row: NotificationRow) =>
-  (value: T | null, column: string) =>
-    value === null
-      ? ParseResult.fail(new ParseResult.Type(ast, row, `${column} required when kind=${row.kind}`))
-      : ParseResult.succeed(value)
-```
-
-## Step 3 — decode with an exhaustive switch
+## Step 2 — decode with an exhaustive switch
 
 `NotificationRow` is a flat struct, not a discriminated union type, so
 `Match.discriminatorsExhaustive` doesn't apply here — it needs a union where
@@ -89,30 +73,36 @@ explicit return type is the right tool: TypeScript narrows the `kind` field in
 each branch, and if you later add a new literal to `Schema.Literal(...)` without
 adding a case, the compiler errors because the function might not return.
 
+The `need` helper is defined inline so TypeScript can infer the generic `T`
+directly from each call site without fighting the curried form.
+
 ```ts
 const decodeRow = (
   row: NotificationRow,
   ast: SchemaAST.Transformation
 ): Effect.Effect<NotificationDomain, ParseResult.ParseIssue> => {
-  const need = required(ast, row)
+  const need = <T>(value: T | null, column: string) =>
+    value === null
+      ? ParseResult.fail(new ParseResult.Type(ast, row, `${column} required when kind=${row.kind}`))
+      : ParseResult.succeed(value)
   switch (row.kind) {
     case "Email":
-      return Effect.all([need(row.email_address, "email_address"), need(row.email_subject, "email_subject")]).pipe(
-        Effect.map(([address, subject]) => Email.make({ id: row.id, address, subject }))
+      return Either.all([need(row.email_address, "email_address"), need(row.email_subject, "email_subject")]).pipe(
+        ParseResult.map(([address, subject]) => Email.make({ id: row.id, address, subject }))
       )
     case "Sms":
       return need(row.sms_phone, "sms_phone").pipe(
-        Effect.map((phone) => Sms.make({ id: row.id, phone }))
+        ParseResult.map((phone) => Sms.make({ id: row.id, phone }))
       )
     case "Push":
-      return Effect.all([need(row.push_device_token, "push_device_token"), need(row.push_title, "push_title")]).pipe(
-        Effect.map(([deviceToken, title]) => Push.make({ id: row.id, deviceToken, title }))
+      return Either.all([need(row.push_device_token, "push_device_token"), need(row.push_title, "push_title")]).pipe(
+        ParseResult.map(([deviceToken, title]) => Push.make({ id: row.id, deviceToken, title }))
       )
   }
 }
 ```
 
-## Step 4 — encode with `Match.tagsExhaustive`
+## Step 3 — encode with `Match.tagsExhaustive`
 
 For the encode direction the situation is different: `NotificationDomain` is a
 proper tagged union (`Schema.Union` of `TaggedStruct` variants), so
@@ -136,7 +126,7 @@ const encodeDomain = Match.type<NotificationDomain>().pipe(
 )
 ```
 
-## Step 5 — wire them with `Schema.transformOrFail`
+## Step 4 — wire them with `Schema.transformOrFail`
 
 ```ts
 const Notification = Schema.transformOrFail(NotificationRow, NotificationDomain, {
@@ -189,7 +179,7 @@ Not every project ends up with wide tables. Two common alternatives:
     var btn = document.getElementById("copy-complete");
     if (!pre || !btn) return;
 
-    pre.textContent = `import { Effect, Match, ParseResult, Schema, SchemaAST } from "effect"
+    pre.textContent = `import { Effect, Either, Match, ParseResult, Schema, SchemaAST } from "effect"
 
 const NotificationRow = Schema.Struct({
   id: Schema.String,
@@ -209,30 +199,26 @@ const Push  = Schema.TaggedStruct("Push",  { id: Schema.String, deviceToken: Sch
 const NotificationDomain = Schema.Union(Email, Sms, Push)
 type NotificationDomain = typeof NotificationDomain.Type
 
-const required =
-  <T>(ast: SchemaAST.AST, row: NotificationRow) =>
-  (value: T | null, column: string) =>
-    value === null
-      ? ParseResult.fail(new ParseResult.Type(ast, row, \`\${column} required when kind=\${row.kind}\`))
-      : ParseResult.succeed(value)
-
 const decodeRow = (
   row: NotificationRow,
   ast: SchemaAST.Transformation
 ): Effect.Effect<NotificationDomain, ParseResult.ParseIssue> => {
-  const need = required(ast, row)
+  const need = <T>(value: T | null, column: string) =>
+    value === null
+      ? ParseResult.fail(new ParseResult.Type(ast, row, \`\${column} required when kind=\${row.kind}\`))
+      : ParseResult.succeed(value)
   switch (row.kind) {
     case "Email":
-      return Effect.all([need(row.email_address, "email_address"), need(row.email_subject, "email_subject")]).pipe(
-        Effect.map(([address, subject]) => Email.make({ id: row.id, address, subject }))
+      return Either.all([need(row.email_address, "email_address"), need(row.email_subject, "email_subject")]).pipe(
+        ParseResult.map(([address, subject]) => Email.make({ id: row.id, address, subject }))
       )
     case "Sms":
       return need(row.sms_phone, "sms_phone").pipe(
-        Effect.map((phone) => Sms.make({ id: row.id, phone }))
+        ParseResult.map((phone) => Sms.make({ id: row.id, phone }))
       )
     case "Push":
-      return Effect.all([need(row.push_device_token, "push_device_token"), need(row.push_title, "push_title")]).pipe(
-        Effect.map(([deviceToken, title]) => Push.make({ id: row.id, deviceToken, title }))
+      return Either.all([need(row.push_device_token, "push_device_token"), need(row.push_title, "push_title")]).pipe(
+        ParseResult.map(([deviceToken, title]) => Push.make({ id: row.id, deviceToken, title }))
       )
   }
 }

--- a/src/content/blog/mapping-db-rows-to-tagged-unions-with-effect-schema.md
+++ b/src/content/blog/mapping-db-rows-to-tagged-unions-with-effect-schema.md
@@ -178,7 +178,18 @@ Not every project ends up with wide tables. Two common alternatives:
     </summary>
     <div class="relative">
       <button id="copy-complete" class="absolute top-3 right-3 z-10 px-2.5 py-1 text-xs font-medium rounded-md bg-gray-700 text-gray-200 hover:bg-gray-600 transition-colors">Copy</button>
-      <pre id="complete-code" class="m-0 rounded-none text-sm p-6 bg-gray-900 dark:bg-gray-950 text-gray-100 overflow-x-auto leading-relaxed"><code>import { Effect, Match, ParseResult, Schema, SchemaAST } from "effect"
+      <pre id="complete-code" class="m-0 rounded-none text-sm p-6 bg-gray-900 dark:bg-gray-950 text-gray-100 overflow-x-auto leading-relaxed"></pre>
+    </div>
+  </details>
+</div>
+
+<script>
+  (function () {
+    var pre = document.getElementById("complete-code");
+    var btn = document.getElementById("copy-complete");
+    if (!pre || !btn) return;
+
+    pre.textContent = `import { Effect, Match, ParseResult, Schema, SchemaAST } from "effect"
 
 const NotificationRow = Schema.Struct({
   id: Schema.String,
@@ -199,29 +210,29 @@ const NotificationDomain = Schema.Union(Email, Sms, Push)
 type NotificationDomain = typeof NotificationDomain.Type
 
 const required =
-  &lt;T&gt;(ast: SchemaAST.AST, row: NotificationRow) =&gt;
-  (value: T | null, column: string) =&gt;
+  <T>(ast: SchemaAST.AST, row: NotificationRow) =>
+  (value: T | null, column: string) =>
     value === null
-      ? ParseResult.fail(new ParseResult.Type(ast, row, `${column} required when kind=${row.kind}`))
+      ? ParseResult.fail(new ParseResult.Type(ast, row, \`\${column} required when kind=\${row.kind}\`))
       : ParseResult.succeed(value)
 
 const decodeRow = (
   row: NotificationRow,
   ast: SchemaAST.Transformation
-): Effect.Effect&lt;NotificationDomain, ParseResult.ParseIssue&gt; =&gt; {
+): Effect.Effect<NotificationDomain, ParseResult.ParseIssue> => {
   const need = required(ast, row)
   switch (row.kind) {
     case "Email":
       return Effect.all([need(row.email_address, "email_address"), need(row.email_subject, "email_subject")]).pipe(
-        Effect.map(([address, subject]) =&gt; Email.make({ id: row.id, address, subject }))
+        Effect.map(([address, subject]) => Email.make({ id: row.id, address, subject }))
       )
     case "Sms":
       return need(row.sms_phone, "sms_phone").pipe(
-        Effect.map((phone) =&gt; Sms.make({ id: row.id, phone }))
+        Effect.map((phone) => Sms.make({ id: row.id, phone }))
       )
     case "Push":
       return Effect.all([need(row.push_device_token, "push_device_token"), need(row.push_title, "push_title")]).pipe(
-        Effect.map(([deviceToken, title]) =&gt; Push.make({ id: row.id, deviceToken, title }))
+        Effect.map(([deviceToken, title]) => Push.make({ id: row.id, deviceToken, title }))
       )
   }
 }
@@ -232,29 +243,21 @@ const nulls = {
   push_device_token: null, push_title: null
 } as const
 
-const encodeDomain = Match.type&lt;NotificationDomain&gt;().pipe(
+const encodeDomain = Match.type<NotificationDomain>().pipe(
   Match.tagsExhaustive({
-    Email: (n) =&gt; ({ ...nulls, id: n.id, kind: "Email" as const, email_address: n.address, email_subject: n.subject }),
-    Sms:   (n) =&gt; ({ ...nulls, id: n.id, kind: "Sms"   as const, sms_phone: n.phone }),
-    Push:  (n) =&gt; ({ ...nulls, id: n.id, kind: "Push"  as const, push_device_token: n.deviceToken, push_title: n.title })
+    Email: (n) => ({ ...nulls, id: n.id, kind: "Email" as const, email_address: n.address, email_subject: n.subject }),
+    Sms:   (n) => ({ ...nulls, id: n.id, kind: "Sms"   as const, sms_phone: n.phone }),
+    Push:  (n) => ({ ...nulls, id: n.id, kind: "Push"  as const, push_device_token: n.deviceToken, push_title: n.title })
   })
 )
 
 const Notification = Schema.transformOrFail(NotificationRow, NotificationDomain, {
-  decode: (row, _opts, ast) =&gt; decodeRow(row, ast),
-  encode: (domain) =&gt; ParseResult.succeed(encodeDomain(domain))
-})</code></pre>
-    </div>
-  </details>
-</div>
+  decode: (row, _opts, ast) => decodeRow(row, ast),
+  encode: (domain) => ParseResult.succeed(encodeDomain(domain))
+})`;
 
-<script>
-  (function () {
-    var btn = document.getElementById("copy-complete");
-    if (!btn) return;
     btn.addEventListener("click", function () {
-      var pre = document.getElementById("complete-code");
-      navigator.clipboard.writeText(pre.innerText).then(function () {
+      navigator.clipboard.writeText(pre.textContent).then(function () {
         btn.textContent = "Copied!";
         setTimeout(function () { btn.textContent = "Copy"; }, 2000);
       });

--- a/src/content/blog/mapping-db-rows-to-tagged-unions-with-effect-schema.md
+++ b/src/content/blog/mapping-db-rows-to-tagged-unions-with-effect-schema.md
@@ -38,12 +38,12 @@ type Notification =
 ```
 
 The solution is a `Schema.transformOrFail` that maps between the two,
-with exhaustiveness for every variant enforced at compile time.
+with exhaustiveness enforced at compile time in both directions.
 
 ## Step 1 — row schema and domain schema
 
 ```ts
-import { Match, ParseResult, Schema, SchemaAST, pipe } from "effect"
+import { Effect, Match, ParseResult, Schema, SchemaAST } from "effect"
 
 const NotificationRow = Schema.Struct({
   id: Schema.String,
@@ -66,7 +66,7 @@ type NotificationDomain = typeof NotificationDomain.Type
 
 ## Step 2 — lift a nullable cell into a `ParseIssue`
 
-`ParseResult.Type` takes an `AST.AST` as its first argument — that's the expected
+`ParseResult.Type` takes a `SchemaAST.AST` as its first argument — the expected
 type description used in error messages. The `ast` the `decode` callback
 receives from `transformOrFail` is `SchemaAST.Transformation`, which is
 a member of that union.
@@ -80,38 +80,45 @@ const required =
       : ParseResult.succeed(value)
 ```
 
-## Step 3 — decode with `Match.discriminatorsExhaustive`
+## Step 3 — decode with an exhaustive switch
 
-`discriminatorsExhaustive("kind")({...})` forces a handler for every
-literal in `kind`. Drop a case → compile error.
+`NotificationRow` is a flat struct, not a discriminated union type, so
+`Match.discriminatorsExhaustive` doesn't apply here — it needs a union where
+each member carries a distinct literal. A `switch` on `row.kind` with an
+explicit return type is the right tool: TypeScript narrows the `kind` field in
+each branch, and if you later add a new literal to `Schema.Literal(...)` without
+adding a case, the compiler errors because the function might not return.
 
 ```ts
-const decodeRow = (row: NotificationRow, ast: SchemaAST.Transformation) => {
+const decodeRow = (
+  row: NotificationRow,
+  ast: SchemaAST.Transformation
+): Effect.Effect<NotificationDomain, ParseResult.ParseIssue> => {
   const need = required(ast, row)
-  return pipe(
-    Match.type<NotificationRow>(),
-    Match.discriminatorsExhaustive("kind")({
-      Email: (r) =>
-        ParseResult.all([need(r.email_address, "email_address"), need(r.email_subject, "email_subject")]).pipe(
-          ParseResult.map(([address, subject]) => Email.make({ id: r.id, address, subject }))
-        ),
-      Sms: (r) =>
-        need(r.sms_phone, "sms_phone").pipe(
-          ParseResult.map((phone) => Sms.make({ id: r.id, phone }))
-        ),
-      Push: (r) =>
-        ParseResult.all([need(r.push_device_token, "push_device_token"), need(r.push_title, "push_title")]).pipe(
-          ParseResult.map(([deviceToken, title]) => Push.make({ id: r.id, deviceToken, title }))
-        )
-    })
-  )(row)
+  switch (row.kind) {
+    case "Email":
+      return Effect.all([need(row.email_address, "email_address"), need(row.email_subject, "email_subject")]).pipe(
+        Effect.map(([address, subject]) => Email.make({ id: row.id, address, subject }))
+      )
+    case "Sms":
+      return need(row.sms_phone, "sms_phone").pipe(
+        Effect.map((phone) => Sms.make({ id: row.id, phone }))
+      )
+    case "Push":
+      return Effect.all([need(row.push_device_token, "push_device_token"), need(row.push_title, "push_title")]).pipe(
+        Effect.map(([deviceToken, title]) => Push.make({ id: row.id, deviceToken, title }))
+      )
+  }
 }
 ```
 
 ## Step 4 — encode with `Match.tagsExhaustive`
 
-On the domain side `_tag` is the discriminator, so use `tagsExhaustive`.
-Again: add a fourth tag to the union → compile error here.
+For the encode direction the situation is different: `NotificationDomain` is a
+proper tagged union (`Schema.Union` of `TaggedStruct` variants), so
+`Match.tagsExhaustive` works correctly here. Each handler receives a
+properly-narrowed type, and adding a fourth variant to the union becomes a
+compile error.
 
 ```ts
 const nulls = {
@@ -144,11 +151,13 @@ const Notification = Schema.transformOrFail(NotificationRow, NotificationDomain,
 
 ## Why this beats `decodeUnknown`
 
-- The exhaustive match helpers reject non-exhaustive handlers at compile time — the same guarantee a
-  `switch` gives with `Match.exhaustive`, but declarative.
 - The row schema is itself a typed `Schema`. Rename a column → DB
   queries and the transform both fail to type-check.
-- Each variant mapping is one line once null-lifting is factored out.
+- The explicit return type on `decodeRow` gives exhaustiveness: add a new
+  literal to `Schema.Literal` and forget the switch case → compile error.
+- `Match.tagsExhaustive` on the encode side gives the same guarantee for
+  the domain → row direction, because `NotificationDomain` is a proper union.
+- Each variant mapping is concise once null-lifting is factored out.
 
 ## Escape hatches
 
@@ -169,7 +178,7 @@ Not every project ends up with wide tables. Two common alternatives:
     </summary>
     <div class="relative">
       <button id="copy-complete" class="absolute top-3 right-3 z-10 px-2.5 py-1 text-xs font-medium rounded-md bg-gray-700 text-gray-200 hover:bg-gray-600 transition-colors">Copy</button>
-      <pre id="complete-code" class="m-0 rounded-none text-sm p-6 bg-gray-900 dark:bg-gray-950 text-gray-100 overflow-x-auto leading-relaxed"><code>import { Match, ParseResult, Schema, SchemaAST, pipe } from "effect"
+      <pre id="complete-code" class="m-0 rounded-none text-sm p-6 bg-gray-900 dark:bg-gray-950 text-gray-100 overflow-x-auto leading-relaxed"><code>import { Effect, Match, ParseResult, Schema, SchemaAST } from "effect"
 
 const NotificationRow = Schema.Struct({
   id: Schema.String,
@@ -196,25 +205,25 @@ const required =
       ? ParseResult.fail(new ParseResult.Type(ast, row, `${column} required when kind=${row.kind}`))
       : ParseResult.succeed(value)
 
-const decodeRow = (row: NotificationRow, ast: SchemaAST.Transformation) =&gt; {
+const decodeRow = (
+  row: NotificationRow,
+  ast: SchemaAST.Transformation
+): Effect.Effect&lt;NotificationDomain, ParseResult.ParseIssue&gt; =&gt; {
   const need = required(ast, row)
-  return pipe(
-    Match.type&lt;NotificationRow&gt;(),
-    Match.discriminatorsExhaustive("kind")({
-      Email: (r) =&gt;
-        ParseResult.all([need(r.email_address, "email_address"), need(r.email_subject, "email_subject")]).pipe(
-          ParseResult.map(([address, subject]) =&gt; Email.make({ id: r.id, address, subject }))
-        ),
-      Sms: (r) =&gt;
-        need(r.sms_phone, "sms_phone").pipe(
-          ParseResult.map((phone) =&gt; Sms.make({ id: r.id, phone }))
-        ),
-      Push: (r) =&gt;
-        ParseResult.all([need(r.push_device_token, "push_device_token"), need(r.push_title, "push_title")]).pipe(
-          ParseResult.map(([deviceToken, title]) =&gt; Push.make({ id: r.id, deviceToken, title }))
-        )
-    })
-  )(row)
+  switch (row.kind) {
+    case "Email":
+      return Effect.all([need(row.email_address, "email_address"), need(row.email_subject, "email_subject")]).pipe(
+        Effect.map(([address, subject]) =&gt; Email.make({ id: row.id, address, subject }))
+      )
+    case "Sms":
+      return need(row.sms_phone, "sms_phone").pipe(
+        Effect.map((phone) =&gt; Sms.make({ id: row.id, phone }))
+      )
+    case "Push":
+      return Effect.all([need(row.push_device_token, "push_device_token"), need(row.push_title, "push_title")]).pipe(
+        Effect.map(([deviceToken, title]) =&gt; Push.make({ id: row.id, deviceToken, title }))
+      )
+  }
 }
 
 const nulls = {

--- a/src/content/blog/mapping-db-rows-to-tagged-unions-with-effect-schema.md
+++ b/src/content/blog/mapping-db-rows-to-tagged-unions-with-effect-schema.md
@@ -66,15 +66,15 @@ type NotificationDomain = typeof NotificationDomain.Type
 
 ## Step 2 — decode with an exhaustive switch
 
-`NotificationRow` is a flat struct, not a discriminated union type, so
-`Match.discriminatorsExhaustive` doesn't apply here — it needs a union where
-each member carries a distinct literal. A `switch` on `row.kind` with an
-explicit return type is the right tool: TypeScript narrows the `kind` field in
-each branch, and if you later add a new literal to `Schema.Literal(...)` without
-adding a case, the compiler errors because the function might not return.
+`decodeRow` switches on `row.kind` and maps each variant to its domain type.
+The explicit return type annotation makes the switch exhaustive: add a new
+literal to `Schema.Literal(...)` without a matching case and the compiler
+will error because the function might not return on all paths.
 
-The `need` helper is defined inline so TypeScript can infer the generic `T`
-directly from each call site without fighting the curried form.
+The `need` helper lifts a nullable column into a `ParseResult.ParseIssue`,
+using the `ast` and `row` already in scope to produce a meaningful error
+message. `Either.all` combines two of these into a single `Either`, and
+`ParseResult.map` maps over the result without leaving the `Either`-land.
 
 ```ts
 const decodeRow = (
@@ -104,11 +104,13 @@ const decodeRow = (
 
 ## Step 3 — encode with `Match.tagsExhaustive`
 
-For the encode direction the situation is different: `NotificationDomain` is a
-proper tagged union (`Schema.Union` of `TaggedStruct` variants), so
-`Match.tagsExhaustive` works correctly here. Each handler receives a
-properly-narrowed type, and adding a fourth variant to the union becomes a
-compile error.
+`NotificationDomain` is a tagged union — a `Schema.Union` of `TaggedStruct`
+variants each carrying a distinct `_tag` literal. `Match.tagsExhaustive`
+requires a handler for every tag in the union at compile time: add a fourth
+variant without a matching handler and it's a compile error.
+
+Each handler spreads a `nulls` baseline and fills in only the columns that
+belong to that variant.
 
 ```ts
 const nulls = {
@@ -141,12 +143,12 @@ const Notification = Schema.transformOrFail(NotificationRow, NotificationDomain,
 
 ## Why this beats `decodeUnknown`
 
-- The row schema is itself a typed `Schema`. Rename a column → DB
-  queries and the transform both fail to type-check.
-- The explicit return type on `decodeRow` gives exhaustiveness: add a new
-  literal to `Schema.Literal` and forget the switch case → compile error.
-- `Match.tagsExhaustive` on the encode side gives the same guarantee for
-  the domain → row direction, because `NotificationDomain` is a proper union.
+- The row schema is a typed `Schema`. Rename a column → DB queries and
+  the transform both fail to type-check.
+- Adding a new `kind` literal without a switch case is a compile error:
+  the explicit return type forces every path to return.
+- Adding a new domain variant without an encode handler is also a compile
+  error: `Match.tagsExhaustive` requires every `_tag` to be covered.
 - Each variant mapping is concise once null-lifting is factored out.
 
 ## Escape hatches


### PR DESCRIPTION
## Summary

- Removes Scenario A (clean rows / no transform needed) — it was a detour that didn't contribute to the core topic
- Reframes the intro as "The problem" and leads directly into the wide-table case
- Rewrites the frontmatter description to be a plain sentence rather than an API name dump
- Fixes three correctness bugs in the code:
  - `ParseResult.ParseIssue["ast"]` → `SchemaAST.AST` (not all `ParseIssue` union members have `ast`)
  - `Match.discriminatorsExhaustive` → `switch` on `row.kind` with an explicit return type (`NotificationRow` is a flat struct, not a discriminated union, so `discriminatorsExhaustive` typed every handler param as `never`)
  - `ParseResult.all` → `Effect.all` (`ParseResult.all` does not exist)
- Keeps `Match.tagsExhaustive` on the encode side, where `NotificationDomain` is a proper tagged union
- Adds a collapsible "Complete example" block at the bottom with a copy button; code is injected via `textContent` so `<`, `>`, `=>` and quotes copy as-is without HTML entity mangling

## Test plan

- [ ] `pnpm run check` passes (0 errors)
- [ ] `pnpm run build` completes successfully
- [ ] Blog post renders correctly and the collapsible block expands
- [ ] Copy button copies valid TypeScript (check `<T>`, `=>`, and the template literal)
