### PR TITLE
Visual redesign: aurora hero, bento projects, scroll reveals

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@astrojs/check": "^0.9.8",
     "@astrojs/react": "^5.0.3",
     "@fontsource-variable/onest": "5.0.2",
+    "@fontsource/instrument-serif": "^5.2.8",
     "@tailwindcss/vite": "^4.1.18",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@fontsource-variable/onest':
         specifier: 5.0.2
         version: 5.0.2
+      '@fontsource/instrument-serif':
+        specifier: ^5.2.8
+        version: 5.2.8
       '@tailwindcss/vite':
         specifier: ^4.1.18
         version: 4.1.18(vite@7.3.2(@types/node@24.0.7)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.3))
@@ -416,6 +419,9 @@ packages:
 
   '@fontsource-variable/onest@5.0.2':
     resolution: {integrity: sha512-XsH6q+/OyO0Oba4OB/NkiQu3ON93U2Kx+1YxKpNZMuS+a+WvxipwhO8Und2CC0mLI33xOZzTWUk4wtnsUJzjCQ==}
+
+  '@fontsource/instrument-serif@5.2.8':
+    resolution: {integrity: sha512-s+bkz+syj2rO00Rmq9g0P+PwuLig33DR1xDR8pTWmovH1pUjwnncrFk++q9mmOex8fUQ7oW80gPpPDaw7V1MMw==}
 
   '@hazae41/berith@1.2.6':
     resolution: {integrity: sha512-TQLkisoolGD2kdSQVtTVXNwmsotA9dLmUgXcpHTNzssmN11Mp+vHVf4Myn3+Q4U18Na3UzGi6DZqogZFqjPPvg==}
@@ -2793,6 +2799,8 @@ snapshots:
       '@expressive-code/core': 0.42.0
 
   '@fontsource-variable/onest@5.0.2': {}
+
+  '@fontsource/instrument-serif@5.2.8': {}
 
   '@hazae41/berith@1.2.6':
     dependencies:

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -15,13 +15,19 @@ type Props = {
 
 const { linkedinUrl, github, name, personalImageAlt, stackOverflow } =
   Astro.props;
+
+const prefixWords = ["Hi,", "I'm"];
+const nameWords = name.split(" ");
 ---
 
-<div class="max-w-xl">
-  <div class="flex gap-4 mb-4">
-    <a href="/profile">
+<div class="max-w-2xl">
+  <div class="flex gap-4 mb-6 items-center">
+    <a
+      href="/profile"
+      class="relative inline-flex p-[2px] rounded-full bg-gradient-to-br from-blue-400 via-violet-500 to-amber-400 shadow-lg hover:shadow-violet-500/30 transition-shadow"
+    >
       <img
-        class="rounded-full shadow-lg size-16"
+        class="rounded-full size-16 ring-2 ring-white/70 dark:ring-gray-900/70"
         src="/danielo-1.webp"
         transition:name="avatar"
         id="avatar"
@@ -37,17 +43,36 @@ const { linkedinUrl, github, name, personalImageAlt, stackOverflow } =
       <Badge>Available for work</Badge>
     </a>
   </div>
+
   <h1
-    class="text-4xl font-bold tracking-tight text-gray-800 sm:text-5xl dark:text-white"
+    class="display text-5xl sm:text-6xl md:text-7xl tracking-tight text-gray-900 dark:text-white leading-[1.05]"
   >
-    Hi, I'm <span class="text-blue-500">{name}</span>
+    {
+      prefixWords.map((word, i) => (
+        <span class="hero-word mr-[0.25em]" style={`--i: ${i}`}>
+          {word}
+        </span>
+      ))
+    }
+    {
+      nameWords.map((word, i) => (
+        <span
+          class="hero-word mr-[0.25em] bg-gradient-to-br from-blue-500 via-violet-500 to-amber-400 bg-clip-text text-transparent italic"
+          style={`--i: ${prefixWords.length + i}`}
+        >
+          {word}
+        </span>
+      ))
+    }
   </h1>
+
   <p
-    class="mt-6 text-xl text-gray-800 dark:[&>strong]:text-yellow-200 [&>strong]:text-yellow-500 [&>strong]:font-semibold dark:text-gray-300"
+    class="mt-6 text-xl text-gray-700 dark:[&>strong]:text-yellow-200 [&>strong]:text-yellow-600 [&>strong]:font-semibold dark:text-gray-300 max-w-xl"
   >
     <slot />
   </p>
-  <nav class="flex flex-wrap gap-4 mt-8 max-sm:justify-center">
+
+  <nav class="flex flex-wrap gap-3 mt-8 max-sm:justify-center">
     <SocialPill href={github}>
       <GitHub class="size-4" />
       Github

--- a/src/components/Projects.astro
+++ b/src/components/Projects.astro
@@ -11,69 +11,107 @@ interface Props {
   projects: Array<CollectionEntry<"projects">>;
 }
 
-const projects = Astro.props.projects;
+const { projects } = Astro.props;
 ---
 
-<div class="flex flex-col gap-y-16">
+<div class="grid grid-cols-1 md:grid-cols-6 gap-6 auto-rows-[minmax(0,_1fr)]">
   {
-    projects.map(
-      async (project) => {
-        const { data: { image, title, tags, url: link, github } } = project;
-        const { Content } = await render(project);
-        return (
-          <Fragment>
-            <article class="flex flex-col space-x-0 space-y-8 group md:flex-row md:space-x-8 md:space-y-0">
-              <div class="w-full md:w-1/2">
-                <div class="relative flex flex-col items-center col-span-6 row-span-5 gap-8 transition duration-500 ease-in-out transform shadow-xl overflow-clip rounded-xl sm:rounded-xl md:group-hover:-translate-y-1 md:group-hover:shadow-2xl lg:border lg:border-gray-800 lg:hover:border-gray-700 lg:hover:bg-gray-800/50">
-                  <Image
-                    alt={title}
-                    class="object-cover object-top w-full h-56 transition duration-500 sm:h-full md:scale-110 md:group-hover:scale-105"
-                    loading="lazy"
-                    src={image}
-                  />
-                </div>
-              </div>
+    projects.map(async (project, idx) => {
+      const {
+        data: { image, title, tags, url: link, github },
+      } = project;
+      const { Content } = await render(project);
 
-              <div class="w-full md:w-1/2 md:max-w-lg">
-                <h3 class="text-2xl font-bold text-gray-800 dark:text-gray-100">
-                  {title}
-                </h3>
-                <div class="flex flex-wrap mt-2">
-                  <ul class="flex flex-row mb-2 gap-x-2">
-                    {tags.map((tag) => (
-                      <li>
-                        <TechTag tag={tag} />
-                      </li>
-                    ))}
-                  </ul>
+      // First project = feature tile (full row on desktop)
+      const isFeature = idx === 0;
+      const tileClass = isFeature
+        ? "md:col-span-6 md:flex-row"
+        : "md:col-span-3 md:flex-col";
 
-                  <div class="mt-2 text-gray-700 dark:text-gray-400">
-                    {<Content />}
-                  </div>
-                  <footer class="flex items-end justify-start mt-4 gap-x-4">
-                    {github && (
-                      <Fragment>
-                        <LinkButton href={github}>
-                          <GitHub class="size-6" />
-                          Code
-                        </LinkButton>
-                      </Fragment>
-                    )}
-                    {link && (
-                      <Fragment>
-                        <LinkButton href={link}>
-                          <Link class="size-4" />
-                          Preview
-                        </LinkButton>
-                      </Fragment>
-                    )}
-                  </footer>
-                </div>
-              </div>
-            </article>
-          </Fragment>
-        );
-      }
-    )
+      return (
+        <article
+          data-spotlight
+          class={`spotlight-card group relative flex flex-col ${tileClass} gap-6 p-5 rounded-2xl border border-gray-200/60 dark:border-white/10 bg-white/40 dark:bg-white/[0.03] backdrop-blur-xl shadow-sm hover:-translate-y-1 hover:shadow-2xl hover:border-violet-300/60 dark:hover:border-violet-400/30 overflow-hidden`}
+        >
+          <span class="spotlight-card-glow" aria-hidden="true" />
+
+          <div
+            class={`relative overflow-hidden rounded-xl ring-1 ring-black/5 dark:ring-white/10 ${
+              isFeature ? "md:w-1/2 md:flex-shrink-0" : "w-full"
+            }`}
+          >
+            <Image
+              alt={title}
+              class={`object-cover object-top w-full transition duration-700 group-hover:scale-105 ${
+                isFeature ? "h-64 md:h-72" : "h-48"
+              }`}
+              loading="lazy"
+              src={image}
+            />
+            <div class="pointer-events-none absolute inset-0 bg-gradient-to-t from-black/40 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity" />
+          </div>
+
+          <div class={`flex flex-col gap-3 ${isFeature ? "md:flex-1" : ""}`}>
+            <h3
+              class={`display tracking-tight text-gray-900 dark:text-white ${
+                isFeature ? "text-3xl md:text-4xl" : "text-2xl"
+              }`}
+            >
+              {title}
+            </h3>
+
+            <ul class="flex flex-wrap gap-2">
+              {tags.map((tag) => (
+                <li>
+                  <TechTag tag={tag} />
+                </li>
+              ))}
+            </ul>
+
+            <div
+              class={`text-gray-700 dark:text-gray-300 leading-relaxed ${
+                isFeature ? "text-base" : "text-sm line-clamp-4"
+              }`}
+            >
+              <Content />
+            </div>
+
+            <footer class="flex items-center mt-auto pt-3 gap-3">
+              {github && (
+                <LinkButton href={github}>
+                  <GitHub class="size-5" />
+                  Code
+                </LinkButton>
+              )}
+              {link && (
+                <LinkButton href={link}>
+                  <Link class="size-4" />
+                  Preview
+                </LinkButton>
+              )}
+            </footer>
+          </div>
+        </article>
+      );
+    })
   }
 </div>
+
+<script>
+  // Cursor-tracking spotlight glow on each project card
+  function bindSpotlights() {
+    const cards = document.querySelectorAll<HTMLElement>("[data-spotlight]");
+    cards.forEach((card) => {
+      if (card.dataset.spotlightBound) return;
+      card.dataset.spotlightBound = "true";
+      card.addEventListener("pointermove", (e) => {
+        const rect = card.getBoundingClientRect();
+        card.style.setProperty("--x", `${e.clientX - rect.left}px`);
+        card.style.setProperty("--y", `${e.clientY - rect.top}px`);
+      });
+    });
+  }
+
+  document.addEventListener("astro:page-load", bindSpotlights);
+  bindSpotlights();
+</script>

--- a/src/components/SectionContainer.astro
+++ b/src/components/SectionContainer.astro
@@ -5,7 +5,7 @@ const { class: className, id } = Astro.props;
 <section
   id={id}
   data-section={id}
-  class={`section ${className} scroll-m-20 w-full mx-auto container lg:max-w-4xl md:max-w-2xl`}
+  class={`section reveal-on-scroll ${className ?? ""} scroll-m-20 w-full mx-auto container lg:max-w-4xl md:max-w-2xl`}
 >
   <slot />
 </section>

--- a/src/components/TitleSection.astro
+++ b/src/components/TitleSection.astro
@@ -1,5 +1,9 @@
+---
+const { className } = Astro.props;
+---
+
 <h2
-	class={`flex items-center mb-6 text-3xl font-semibold gap-x-3 text-black/80 dark:text-white ${Astro.props.className}`}
+  class={`display flex items-center mb-8 text-4xl md:text-5xl gap-x-3 text-gray-900 dark:text-white tracking-tight ${className ?? ""}`}
 >
-    <slot />
+  <slot />
 </h2>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,5 +1,7 @@
 ---
 import "@fontsource-variable/onest";
+import "@fontsource/instrument-serif/400.css";
+import "@fontsource/instrument-serif/400-italic.css";
 import "@/styles/global.css";
 
 import { ClientRouter } from "astro:transitions";
@@ -29,12 +31,37 @@ const { title, description = "" } = Astro.props;
   </head>
 
   <body class="relative text-black dark:text-white">
-    <div
-      class="absolute top-0 bottom-0 z-[-2] min-h-screen w-full bg-gray-50 dark:bg-gray-950
-      bg-[radial-gradient(ellipse_80%_80%_at_50%_-20%,rgba(217,216,255,0.5),rgba(255,255,255,0.9))]
-      dark:bg-[radial-gradient(ellipse_80%_80%_at_50%_-20%,rgba(120,119,198,0.3),rgba(255,255,255,0))]"
-    >
+    <!-- Animated aurora backdrop -->
+    <div class="aurora-stage" aria-hidden="true">
+      <div
+        class="aurora-blob"
+        style="top:-12%; left:-8%; width:55vw; height:55vw; background:radial-gradient(circle at 30% 30%, var(--color-brand-blue), transparent 60%); animation: var(--animate-aurora-1);"
+      >
+      </div>
+      <div
+        class="aurora-blob"
+        style="top:10%; right:-12%; width:48vw; height:48vw; background:radial-gradient(circle at 70% 30%, var(--color-brand-violet), transparent 60%); animation: var(--animate-aurora-2);"
+      >
+      </div>
+      <div
+        class="aurora-blob"
+        style="bottom:-18%; left:20%; width:60vw; height:60vw; background:radial-gradient(circle at 50% 50%, var(--color-brand-amber), transparent 65%); animation: var(--animate-aurora-3); opacity:.35;"
+      >
+      </div>
     </div>
+    <div class="noise-overlay" aria-hidden="true"></div>
+
+    <!-- Top scroll progress bar -->
+    <div
+      class="fixed top-0 left-0 right-0 h-[3px] z-50 pointer-events-none"
+      aria-hidden="true"
+    >
+      <div
+        class="scroll-progress-bar h-full w-full origin-left bg-gradient-to-r from-blue-500 via-violet-500 to-amber-400 shadow-[0_0_12px_rgba(99,102,241,0.6)]"
+      >
+      </div>
+    </div>
+
     <slot />
     <style is:global>
       @reference "../styles/global.css";
@@ -44,7 +71,7 @@ const { title, description = "" } = Astro.props;
       }
 
       html {
-        font-family: "Onest Variable", system-ui, sans-serif;
+        font-family: var(--font-sans);
         scroll-behavior: smooth;
       }
 
@@ -56,6 +83,15 @@ const { title, description = "" } = Astro.props;
         overscroll-behavior: none;
       }
 
+      /* Display-serif applied to top-level page headings */
+      h1.display,
+      h2.display,
+      h3.display {
+        font-family: var(--font-display);
+        font-weight: 400;
+        letter-spacing: -0.01em;
+      }
+
       .strong {
         @apply dark:text-yellow-200 text-yellow-500 font-semibold;
       }
@@ -63,6 +99,9 @@ const { title, description = "" } = Astro.props;
       @media (prefers-reduced-motion: reduce) {
         html {
           scroll-behavior: auto;
+        }
+        .aurora-blob {
+          animation: none !important;
         }
       }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,24 +1,168 @@
 @import "tailwindcss";
 @plugin "@tailwindcss/typography";
 
-/* Custom theme extensions migrated from tailwind.config.mjs */
+/* Make the `.dark` class on <html> drive Tailwind's dark variant
+   (matches the ThemeToggle's class-toggling behavior) */
+@custom-variant dark (&:where(.dark, .dark *));
+
+/* Design tokens + custom utilities */
 @theme {
+  --font-display: "Instrument Serif", "Onest Variable", ui-serif, Georgia, serif;
+  --font-sans: "Onest Variable", system-ui, sans-serif;
+
+  /* Brand accents in oklch — vivid in light & dark */
+  --color-brand-blue: oklch(0.66 0.21 252);
+  --color-brand-blue-soft: oklch(0.78 0.16 252);
+  --color-brand-amber: oklch(0.83 0.17 82);
+  --color-brand-violet: oklch(0.66 0.22 295);
+  --color-brand-rose: oklch(0.7 0.2 12);
+
   --animate-bounce-right: slide-in 0.5s ease-in-out infinite alternate;
+  --animate-aurora-1: aurora-1 22s ease-in-out infinite alternate;
+  --animate-aurora-2: aurora-2 28s ease-in-out infinite alternate;
+  --animate-aurora-3: aurora-3 34s ease-in-out infinite alternate;
+  --animate-fade-up: fade-up 0.7s ease-out both;
 
   @keyframes slide-in {
-    0% {
-      transform: translateX(0);
-    }
-    100% {
-      transform: translateX(1rem);
+    0% { transform: translateX(0); }
+    100% { transform: translateX(1rem); }
+  }
+
+  @keyframes aurora-1 {
+    0% { transform: translate3d(-12%, -8%, 0) scale(1); }
+    100% { transform: translate3d(8%, 12%, 0) scale(1.15); }
+  }
+  @keyframes aurora-2 {
+    0% { transform: translate3d(20%, -4%, 0) scale(1.1); }
+    100% { transform: translate3d(-10%, 18%, 0) scale(1); }
+  }
+  @keyframes aurora-3 {
+    0% { transform: translate3d(0%, 20%, 0) scale(0.95); }
+    100% { transform: translate3d(14%, -12%, 0) scale(1.2); }
+  }
+
+  @keyframes fade-up {
+    0% { opacity: 0; transform: translateY(28px); }
+    100% { opacity: 1; transform: translateY(0); }
+  }
+
+  @keyframes word-rise {
+    0% { opacity: 0; transform: translateY(0.4em); filter: blur(8px); }
+    100% { opacity: 1; transform: translateY(0); filter: blur(0); }
+  }
+}
+
+/* Visible-link helper used in MD content blocks */
+@utility visible-links {
+  & a { color: var(--color-blue-500); }
+}
+
+/* Animated aurora layer — sits behind everything in BaseLayout */
+@utility aurora-stage {
+  position: fixed;
+  inset: 0;
+  z-index: -2;
+  overflow: hidden;
+  pointer-events: none;
+  background:
+    radial-gradient(ellipse 80% 80% at 50% -20%, rgba(217, 216, 255, 0.55), rgba(255, 255, 255, 0)) ,
+    linear-gradient(180deg, #f8fafc 0%, #f1f5f9 100%);
+}
+
+:where(.dark) .aurora-stage {
+  background:
+    radial-gradient(ellipse 80% 80% at 50% -20%, rgba(120, 119, 198, 0.25), rgba(255, 255, 255, 0)),
+    linear-gradient(180deg, #030712 0%, #050816 100%);
+}
+
+@utility aurora-blob {
+  position: absolute;
+  border-radius: 9999px;
+  filter: blur(80px);
+  opacity: 0.55;
+  will-change: transform;
+}
+
+@utility aurora-blob-dark {
+  opacity: 0.35;
+  filter: blur(110px);
+}
+
+/* SVG noise overlay — adds film-grain texture */
+@utility noise-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  opacity: 0.06;
+  mix-blend-mode: overlay;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='160' height='160'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.5 0'/></filter><rect width='100%25' height='100%25' filter='url(%23n)'/></svg>");
+}
+
+:where(.dark) .noise-overlay {
+  opacity: 0.09;
+  mix-blend-mode: soft-light;
+}
+
+/* Spotlight card — radial gradient follows cursor via --x / --y */
+@utility spotlight-card {
+  position: relative;
+  isolation: isolate;
+  transition: transform 0.4s cubic-bezier(0.22, 1, 0.36, 1), border-color 0.3s;
+}
+
+@utility spotlight-card-glow {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.3s;
+  background: radial-gradient(
+    320px circle at var(--x, 50%) var(--y, 50%),
+    rgba(99, 102, 241, 0.28),
+    transparent 60%
+  );
+}
+
+.spotlight-card:hover .spotlight-card-glow,
+.spotlight-card:focus-within .spotlight-card-glow {
+  opacity: 1;
+}
+
+/* Scroll-driven section reveal (modern browsers) */
+@supports (animation-timeline: view()) {
+  @media (prefers-reduced-motion: no-preference) {
+    .reveal-on-scroll {
+      animation: fade-up linear both;
+      animation-timeline: view();
+      animation-range: entry 0% cover 35%;
     }
   }
 }
 
-/* Custom utility for visible links */
-@utility visible-links {
-  & a {
-    color: var(--color-blue-500);
+/* Top scroll-progress bar */
+@supports (animation-timeline: scroll()) {
+  @media (prefers-reduced-motion: no-preference) {
+    .scroll-progress-bar {
+      transform-origin: 0 50%;
+      animation: progress-grow linear both;
+      animation-timeline: scroll(root);
+    }
+  }
+}
+@keyframes progress-grow {
+  from { transform: scaleX(0); }
+  to { transform: scaleX(1); }
+}
+
+/* Hero word-rise animation, staggered via inline --i */
+@media (prefers-reduced-motion: no-preference) {
+  .hero-word {
+    display: inline-block;
+    opacity: 0;
+    animation: word-rise 0.7s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+    animation-delay: calc(var(--i, 0) * 70ms + 120ms);
   }
 }
 


### PR DESCRIPTION
## Summary

A visual refresh of the homepage focused on five high‑impact, low‑risk upgrades. All effects are CSS‑first and gated behind `prefers-reduced-motion`.

### Hero
- New display serif (**Instrument Serif**) for the H1, paired with the existing Onest sans for body text.
- Word‑by‑word fade/blur reveal on the headline, staggered via `--i` custom property (no JS).
- Name rendered with a blue → violet → amber gradient clip and italic.
- Avatar wrapped in a soft gradient ring.

### Background
- Replaced the static radial gradient with an **animated aurora**: three blurred radial blobs in brand colors slowly drifting on `@keyframes` (one fixed canvas, not per‑section).
- SVG fractal‑noise overlay for a subtle film‑grain texture.

### Projects → bento grid
- Converted the vertical stack into a 2‑column bento with the first project as a full‑width **feature tile**.
- Frosted glass cards (`backdrop-blur-xl`) with cursor‑tracking **spotlight glow** (radial gradient that follows the pointer via `--x` / `--y` CSS vars).
- Image scale + overlay on hover, gradient border accent on focus.

### Scroll feel
- `SectionContainer` now fades up on entry using **`animation-timeline: view()`** (modern browsers, gracefully no‑ops elsewhere).
- Top **scroll‑progress bar** driven by `animation-timeline: scroll(root)` — gradient blue/violet/amber, no JS.

### Polish
- Brand color tokens in **oklch** for vivid accents in both light and dark.
- Registered `@custom-variant dark (&:where(.dark, .dark *))` so the existing `ThemeToggle` actually drives Tailwind v4 `dark:` utilities (it was previously a no‑op since v4 defaults to `prefers-color-scheme`).
- Reduced‑motion users get a static aurora and instant section reveals.

## Test plan
- [ ] Verify hero headline animates on first paint and respects `prefers-reduced-motion`
- [ ] Confirm aurora blobs drift smoothly on desktop and degrade well on mobile
- [ ] Hover each project card and confirm spotlight follows the cursor
- [ ] Scroll the homepage and confirm the top progress bar fills 0 → 100%
- [ ] Toggle the theme menu (Light/Dark/System) and confirm dark mode now actually flips
- [ ] Run Lighthouse for a performance baseline (blur‑heavy effects can be costly on low‑end devices)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Umt99MwVAsa5ueH3XtHnuC)_