### PR TITLE
Sync workout tracker across devices with Jazz

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@astrojs/check": "^0.9.8",
     "@astrojs/react": "^5.0.3",
     "@fontsource-variable/onest": "5.0.2",
+    "@scure/bip39": "^2.2.0",
     "@tailwindcss/vite": "^4.1.18",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@fontsource-variable/onest':
         specifier: 5.0.2
         version: 5.0.2
+      '@scure/bip39':
+        specifier: ^2.2.0
+        version: 2.2.0
       '@tailwindcss/vite':
         specifier: ^4.1.18
         version: 4.1.18(vite@7.3.2(@types/node@24.0.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.47.1)(yaml@2.8.3))
@@ -606,6 +609,10 @@ packages:
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
 
+  '@noble/hashes@2.2.0':
+    resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
+    engines: {node: '>= 20.19.0'}
+
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
@@ -825,8 +832,14 @@ packages:
   '@scure/base@1.2.6':
     resolution: {integrity: sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==}
 
+  '@scure/base@2.2.0':
+    resolution: {integrity: sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==}
+
   '@scure/bip39@1.6.0':
     resolution: {integrity: sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==}
+
+  '@scure/bip39@2.2.0':
+    resolution: {integrity: sha512-T/Bj/YvYMNkIPq6EENO6/rcs2e7qTNuyoUXf0KBFDmp0ZDu0H2X4Lq6yC3i0c8PcWkov5EbW+yQZZbdMmk154A==}
 
   '@shikijs/core@4.0.2':
     resolution: {integrity: sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw==}
@@ -3694,6 +3707,8 @@ snapshots:
 
   '@noble/hashes@1.8.0': {}
 
+  '@noble/hashes@2.2.0': {}
+
   '@opentelemetry/api@1.9.0': {}
 
   '@oslojs/encoding@1.1.0': {}
@@ -3857,10 +3872,17 @@ snapshots:
 
   '@scure/base@1.2.6': {}
 
+  '@scure/base@2.2.0': {}
+
   '@scure/bip39@1.6.0':
     dependencies:
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
+
+  '@scure/bip39@2.2.0':
+    dependencies:
+      '@noble/hashes': 2.2.0
+      '@scure/base': 2.2.0
 
   '@shikijs/core@4.0.2':
     dependencies:

--- a/src/components/Workout/WorkoutApp.tsx
+++ b/src/components/Workout/WorkoutApp.tsx
@@ -1,4 +1,25 @@
-import { useState, useEffect, useRef, useCallback } from "react";
+import {
+  useState,
+  useEffect,
+  useRef,
+  useCallback,
+  type CSSProperties,
+} from "react";
+import {
+  JazzReactProvider,
+  useAccount,
+  usePassphraseAuth,
+} from "jazz-tools/react";
+import { wordlist } from "@scure/bip39/wordlists/spanish.js";
+import {
+  WorkoutAccount,
+  createRoutineState,
+  legacyRoutineId,
+  loadLegacyRoutine,
+} from "./schema/Workout";
+
+const SYNC_PEER =
+  "wss://cloud.jazz.tools/?key=workout-tracker@danielo515.github.io";
 
 // ─── TYPES ───────────────────────────────────────────────────────────────────
 
@@ -1004,91 +1025,73 @@ function RestTimerBar({
 
 // ─── MAIN APP ────────────────────────────────────────────────────────────────
 
-export default function WorkoutApp() {
-  // ── Helpers for per-routine localStorage ──
-  const loadActiveDay = (rid: string) => {
-    try {
-      const saved = localStorage.getItem(`workout-${rid}-active-day`);
-      return saved ? Number(saved) : 0;
-    } catch {
-      return 0;
-    }
-  };
-  const loadCompleted = (rid: string): Record<string, number> => {
-    try {
-      const saved = localStorage.getItem(`workout-${rid}-completed`);
-      return saved ? JSON.parse(saved) : {};
-    } catch {
-      return {};
-    }
-  };
-  const loadWeekHistory = (rid: string): number[] => {
-    try {
-      const saved = localStorage.getItem(`workout-${rid}-week-history`);
-      return saved ? JSON.parse(saved) : [];
-    } catch {
-      return [];
-    }
-  };
+const ROUTINE_IDS = ["a", "b", "c"];
 
-  // ── Routine selection (new routine "c" is default) ──
-  const [activeRoutineId, setActiveRoutineId] = useState(() => {
-    try {
-      // Migration: move old data to routine "a" namespace
-      if (!localStorage.getItem("workout-routine")) {
-        const oldCompleted = localStorage.getItem("workout-completed");
-        const oldActiveDay = localStorage.getItem("workout-active-day");
-        const oldWeekHistory = localStorage.getItem("workout-week-history");
-        if (oldCompleted) localStorage.setItem("workout-a-completed", oldCompleted);
-        if (oldActiveDay) localStorage.setItem("workout-a-active-day", oldActiveDay);
-        if (oldWeekHistory) localStorage.setItem("workout-a-week-history", oldWeekHistory);
-        localStorage.setItem("workout-routine", "c");
-        return "c";
-      }
-      return localStorage.getItem("workout-routine") || "c";
-    } catch {
-      return "c";
-    }
+function WorkoutTracker() {
+  const me = useAccount(WorkoutAccount, {
+    resolve: {
+      root: { routines: { $each: { completed: true, weekHistory: true } } },
+    },
   });
+  const { secondsLeft, running, start, stop } = useRestTimer();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // Seed any missing routine state from the pre-Jazz localStorage data.
+  useEffect(() => {
+    if (!me.$isLoaded) return;
+    const root = me.root;
+    const wasEmpty = ROUTINE_IDS.every((id) => !root.routines.$jazz.has(id));
+    for (const rid of ROUTINE_IDS) {
+      if (!root.routines.$jazz.has(rid)) {
+        root.routines.$jazz.set(rid, createRoutineState(loadLegacyRoutine(rid)));
+      }
+    }
+    if (wasEmpty) {
+      const legacy = legacyRoutineId();
+      if (legacy && ROUTINE_IDS.includes(legacy)) {
+        root.$jazz.set("activeRoutineId", legacy);
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [me.$isLoaded]);
+
+  if (!me.$isLoaded) return <LoadingScreen />;
+
+  const appRoot = me.root;
+  const activeRoutineId = appRoot.activeRoutineId;
+  const routineState = appRoot.routines[activeRoutineId];
+  if (!routineState?.$isLoaded) return <LoadingScreen />;
 
   const routine = routines.find((r) => r.id === activeRoutineId) ?? routines[2]!;
   const workoutData = routine.workoutData;
   const weeklyExercises = routine.weeklyExercises;
 
-  const [activeDay, setActiveDay] = useState(() => loadActiveDay(activeRoutineId));
-  const [completed, setCompleted] = useState<Record<string, number>>(() => loadCompleted(activeRoutineId));
-  const [weekHistory, setWeekHistory] = useState<number[]>(() => loadWeekHistory(activeRoutineId));
-  const { secondsLeft, running, start, stop } = useRestTimer();
+  const completed = routineState.completed;
+  const weekHistory = routineState.weekHistory;
+  const activeDay = Math.max(
+    0,
+    Math.min(routineState.activeDay, workoutData.length - 1),
+  );
+
+  const setActiveDay = (i: number) => routineState.$jazz.set("activeDay", i);
 
   const switchRoutine = (newId: string) => {
-    setActiveRoutineId(newId);
-    localStorage.setItem("workout-routine", newId);
-    setActiveDay(loadActiveDay(newId));
-    setCompleted(loadCompleted(newId));
-    setWeekHistory(loadWeekHistory(newId));
+    if (!appRoot.routines.$jazz.has(newId)) {
+      appRoot.routines.$jazz.set(
+        newId,
+        createRoutineState(loadLegacyRoutine(newId)),
+      );
+    }
+    appRoot.$jazz.set("activeRoutineId", newId);
   };
-
-  useEffect(() => {
-    localStorage.setItem(`workout-${activeRoutineId}-active-day`, String(activeDay));
-  }, [activeDay, activeRoutineId]);
-
-  useEffect(() => {
-    localStorage.setItem(`workout-${activeRoutineId}-completed`, JSON.stringify(completed));
-  }, [completed, activeRoutineId]);
-
-  useEffect(() => {
-    localStorage.setItem(`workout-${activeRoutineId}-week-history`, JSON.stringify(weekHistory));
-  }, [weekHistory, activeRoutineId]);
 
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const day = workoutData[activeDay]!;
 
   const handleSetDone = (exerciseId: string, setNum: number) => {
-    setCompleted((prev) => {
-      const current = prev[exerciseId] ?? 0;
-      const newVal = current === setNum ? setNum - 1 : setNum;
-      return { ...prev, [exerciseId]: newVal };
-    });
+    const current = completed[exerciseId] ?? 0;
+    const newVal = current === setNum ? setNum - 1 : setNum;
+    completed.$jazz.set(exerciseId, newVal);
   };
 
   const getTotalSets = (d: WorkoutDay) =>
@@ -1106,12 +1109,9 @@ export default function WorkoutApp() {
   const progressPct = dayTotal > 0 ? (dayProgress / dayTotal) * 100 : 0;
 
   const resetDay = () => {
-    const ids = day.groups.flatMap((g) => g.exercises.map((e) => e.id));
-    setCompleted((prev) => {
-      const next = { ...prev };
-      ids.forEach((id) => delete next[id]);
-      return next;
-    });
+    day.groups
+      .flatMap((g) => g.exercises.map((e) => e.id))
+      .forEach((id) => completed.$jazz.delete(id));
   };
 
   const allDaysComplete = workoutData.every(
@@ -1129,20 +1129,18 @@ export default function WorkoutApp() {
 
   const completeWeek = () => {
     if (!allWeekComplete) return;
-    setWeekHistory((prev) => [...prev, Date.now()]);
-    setCompleted({});
-    setActiveDay(0);
+    weekHistory.$jazz.push(Date.now());
+    Object.keys(completed).forEach((key) => completed.$jazz.delete(key));
+    routineState.$jazz.set("activeDay", 0);
   };
-
-  const fileInputRef = useRef<HTMLInputElement>(null);
 
   const exportData = () => {
     const data = {
       version: 1,
       exportedAt: new Date().toISOString(),
       activeDay,
-      completed,
-      weekHistory,
+      completed: { ...completed },
+      weekHistory: [...weekHistory],
     };
     const blob = new Blob([JSON.stringify(data, null, 2)], {
       type: "application/json",
@@ -1160,9 +1158,22 @@ export default function WorkoutApp() {
     reader.onload = (e) => {
       try {
         const data = JSON.parse(e.target?.result as string);
-        if (data.completed) setCompleted(data.completed);
-        if (data.weekHistory) setWeekHistory(data.weekHistory);
-        if (typeof data.activeDay === "number") setActiveDay(data.activeDay);
+        if (data.completed && typeof data.completed === "object") {
+          Object.keys(completed).forEach((key) => completed.$jazz.delete(key));
+          for (const [key, value] of Object.entries(data.completed)) {
+            completed.$jazz.set(key, Number(value));
+          }
+        }
+        if (Array.isArray(data.weekHistory)) {
+          weekHistory.$jazz.splice(
+            0,
+            weekHistory.length,
+            ...data.weekHistory.map(Number),
+          );
+        }
+        if (typeof data.activeDay === "number") {
+          routineState.$jazz.set("activeDay", data.activeDay);
+        }
       } catch {
         alert("Error al leer el archivo de backup");
       }
@@ -1748,6 +1759,9 @@ export default function WorkoutApp() {
         </button>
       </div>
 
+      {/* Sync */}
+      <SyncPanel color={day.color} />
+
       {/* Rest timer */}
       <RestTimerBar
         secondsLeft={secondsLeft}
@@ -1757,5 +1771,279 @@ export default function WorkoutApp() {
         color={day.color}
       />
     </div>
+  );
+}
+
+// ─── LOADING ─────────────────────────────────────────────────────────────────
+
+function LoadingScreen() {
+  return (
+    <div
+      style={{
+        minHeight: "100vh",
+        background: "#0a0a0a",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
+      <span
+        style={{
+          fontFamily: "'Barlow Condensed', sans-serif",
+          fontSize: 13,
+          letterSpacing: "0.14em",
+          color: "#444",
+          textTransform: "uppercase",
+        }}
+      >
+        Cargando…
+      </span>
+    </div>
+  );
+}
+
+// ─── SYNC PANEL ──────────────────────────────────────────────────────────────
+
+function SyncPanel({ color }: { color: string }) {
+  const auth = usePassphraseAuth({ wordlist });
+  const [showPhrase, setShowPhrase] = useState(false);
+  const [showLogin, setShowLogin] = useState(false);
+  const [loginPhrase, setLoginPhrase] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+  const [copied, setCopied] = useState(false);
+
+  const signedIn = auth.state === "signedIn";
+
+  const enableSync = async () => {
+    setBusy(true);
+    setError("");
+    try {
+      await auth.signUp();
+      setShowPhrase(true);
+    } catch {
+      setError("No se pudo activar la sincronización. Inténtalo de nuevo.");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const logIn = async () => {
+    const phrase = loginPhrase.trim().replace(/\s+/g, " ");
+    if (!phrase) return;
+    setBusy(true);
+    setError("");
+    try {
+      await auth.logIn(phrase);
+      setShowLogin(false);
+      setLoginPhrase("");
+    } catch {
+      setError("La frase no es válida. Revísala e inténtalo de nuevo.");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const copyPhrase = async () => {
+    try {
+      await navigator.clipboard.writeText(auth.passphrase);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      /* clipboard unavailable */
+    }
+  };
+
+  const sectionLabel: CSSProperties = {
+    fontFamily: "'Barlow Condensed', sans-serif",
+    fontSize: 10,
+    fontWeight: 700,
+    color: "#444",
+    letterSpacing: "0.14em",
+    textTransform: "uppercase",
+    marginBottom: 8,
+  };
+  const bodyText: CSSProperties = {
+    fontFamily: "'Barlow', sans-serif",
+    fontSize: 12,
+    color: "#888",
+    lineHeight: 1.5,
+  };
+  const primaryBtn: CSSProperties = {
+    fontFamily: "'Barlow Condensed', sans-serif",
+    fontSize: 12,
+    fontWeight: 800,
+    letterSpacing: "0.1em",
+    textTransform: "uppercase",
+    width: "100%",
+    padding: "11px 14px",
+    background: busy ? "#1a1a1a" : color,
+    color: busy ? "#444" : "#000",
+    border: `1px solid ${busy ? "#222" : color}`,
+    borderRadius: 6,
+    cursor: busy ? "default" : "pointer",
+  };
+  const ghostBtn: CSSProperties = {
+    fontFamily: "'Barlow Condensed', sans-serif",
+    fontSize: 11,
+    fontWeight: 700,
+    letterSpacing: "0.08em",
+    textTransform: "uppercase",
+    background: "transparent",
+    color: "#666",
+    border: "none",
+    padding: "8px 0 0",
+    cursor: "pointer",
+  };
+
+  return (
+    <div style={{ padding: "16px 20px 0" }}>
+      <div style={sectionLabel}>Sincronización</div>
+      <div
+        style={{
+          background: "#111",
+          border: "1px solid #1a1a1a",
+          borderRadius: 8,
+          padding: 14,
+          display: "flex",
+          flexDirection: "column",
+          gap: 10,
+        }}
+      >
+        {signedIn ? (
+          <>
+            <div
+              style={{
+                fontFamily: "'Barlow Condensed', sans-serif",
+                fontSize: 13,
+                fontWeight: 700,
+                letterSpacing: "0.06em",
+                color: "#22c55e",
+                textTransform: "uppercase",
+              }}
+            >
+              ✓ Sincronización activa
+            </div>
+            <div style={bodyText}>
+              Tu progreso se sincroniza entre tus dispositivos.
+            </div>
+            <button
+              type="button"
+              style={ghostBtn}
+              onClick={() => setShowPhrase((v) => !v)}
+            >
+              {showPhrase ? "Ocultar frase" : "Ver frase de recuperación"}
+            </button>
+          </>
+        ) : (
+          <>
+            <div style={bodyText}>
+              Tus datos se guardan solo en este dispositivo. Activa la
+              sincronización para acceder a tu progreso desde otros
+              dispositivos.
+            </div>
+            <button
+              type="button"
+              style={primaryBtn}
+              disabled={busy}
+              onClick={enableSync}
+            >
+              {busy ? "Activando…" : "Activar sincronización"}
+            </button>
+            <button
+              type="button"
+              style={ghostBtn}
+              onClick={() => {
+                setShowLogin((v) => !v);
+                setError("");
+              }}
+            >
+              {showLogin ? "Cancelar" : "Ya tengo una frase de recuperación"}
+            </button>
+            {showLogin && (
+              <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                <textarea
+                  value={loginPhrase}
+                  onChange={(e) => setLoginPhrase(e.target.value)}
+                  placeholder="Escribe aquí tu frase de recuperación"
+                  rows={3}
+                  style={{
+                    fontFamily: "'Barlow', sans-serif",
+                    fontSize: 13,
+                    color: "#fff",
+                    background: "#0a0a0a",
+                    border: "1px solid #222",
+                    borderRadius: 6,
+                    padding: "8px 10px",
+                    resize: "vertical",
+                  }}
+                />
+                <button
+                  type="button"
+                  style={primaryBtn}
+                  disabled={busy || !loginPhrase.trim()}
+                  onClick={logIn}
+                >
+                  {busy ? "Entrando…" : "Entrar"}
+                </button>
+              </div>
+            )}
+          </>
+        )}
+
+        {showPhrase && signedIn && (
+          <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+            <div
+              style={{
+                fontFamily: "'Barlow', sans-serif",
+                fontSize: 14,
+                color: "#fff",
+                lineHeight: 1.6,
+                background: "#0a0a0a",
+                border: `1px solid ${color}44`,
+                borderRadius: 6,
+                padding: "10px 12px",
+                wordSpacing: "0.15em",
+              }}
+            >
+              {auth.passphrase}
+            </div>
+            <button type="button" style={primaryBtn} onClick={copyPhrase}>
+              {copied ? "✓ Copiada" : "Copiar frase"}
+            </button>
+            <div style={{ ...bodyText, color: "#666", fontSize: 11 }}>
+              Guárdala en un lugar seguro. La necesitarás para acceder a tu
+              progreso desde otro dispositivo.
+            </div>
+          </div>
+        )}
+
+        {error && (
+          <div
+            style={{
+              fontFamily: "'Barlow', sans-serif",
+              fontSize: 12,
+              color: "#ef4444",
+            }}
+          >
+            {error}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─── ROOT (Jazz provider) ────────────────────────────────────────────────────
+
+export default function WorkoutApp() {
+  return (
+    <JazzReactProvider
+      sync={{ peer: SYNC_PEER }}
+      AccountSchema={WorkoutAccount}
+      fallback={<LoadingScreen />}
+    >
+      <WorkoutTracker />
+    </JazzReactProvider>
   );
 }

--- a/src/components/Workout/WorkoutApp.tsx
+++ b/src/components/Workout/WorkoutApp.tsx
@@ -1036,6 +1036,10 @@ function WorkoutTracker() {
   const { secondsLeft, running, start, stop } = useRestTimer();
   const fileInputRef = useRef<HTMLInputElement>(null);
 
+  // Re-runs when the active account changes (e.g. after logging in with a
+  // recovery phrase), so a freshly switched-to account is seeded too.
+  const accountId = me.$isLoaded ? me.$jazz.id : null;
+
   // Seed any missing routine state from the pre-Jazz localStorage data.
   useEffect(() => {
     if (!me.$isLoaded) return;
@@ -1053,9 +1057,15 @@ function WorkoutTracker() {
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [me.$isLoaded]);
+  }, [accountId]);
 
-  if (!me.$isLoaded) return <LoadingScreen />;
+  if (!me.$isLoaded) {
+    if (me.$jazz.loadingState === "unauthorized")
+      return <LoadingScreen message="No tienes acceso a esta cuenta." />;
+    if (me.$jazz.loadingState === "unavailable")
+      return <LoadingScreen message="No se pudo cargar tu cuenta." />;
+    return <LoadingScreen />;
+  }
 
   const appRoot = me.root;
   const activeRoutineId = appRoot.activeRoutineId;
@@ -1079,7 +1089,7 @@ function WorkoutTracker() {
     if (!appRoot.routines.$jazz.has(newId)) {
       appRoot.routines.$jazz.set(
         newId,
-        createRoutineState(loadLegacyRoutine(newId)),
+        createRoutineState({ activeDay: 0, completed: {}, weekHistory: [] }),
       );
     }
     appRoot.$jazz.set("activeRoutineId", newId);
@@ -1776,7 +1786,7 @@ function WorkoutTracker() {
 
 // ─── LOADING ─────────────────────────────────────────────────────────────────
 
-function LoadingScreen() {
+function LoadingScreen({ message = "Cargando…" }: { message?: string }) {
   return (
     <div
       style={{
@@ -1796,7 +1806,7 @@ function LoadingScreen() {
           textTransform: "uppercase",
         }}
       >
-        Cargando…
+        {message}
       </span>
     </div>
   );

--- a/src/components/Workout/WorkoutApp.tsx
+++ b/src/components/Workout/WorkoutApp.tsx
@@ -1171,17 +1171,22 @@ function WorkoutTracker() {
         if (data.completed && typeof data.completed === "object") {
           Object.keys(completed).forEach((key) => completed.$jazz.delete(key));
           for (const [key, value] of Object.entries(data.completed)) {
-            completed.$jazz.set(key, Number(value));
+            if (key === "__proto__" || key === "constructor") continue;
+            const num = Number(value);
+            if (!Number.isFinite(num)) continue;
+            completed.$jazz.set(key, num);
           }
         }
         if (Array.isArray(data.weekHistory)) {
-          weekHistory.$jazz.splice(
-            0,
-            weekHistory.length,
-            ...data.weekHistory.map(Number),
-          );
+          const ts = data.weekHistory
+            .map(Number)
+            .filter((n: number) => Number.isFinite(n));
+          weekHistory.$jazz.splice(0, weekHistory.length, ...ts);
         }
-        if (typeof data.activeDay === "number") {
+        if (
+          typeof data.activeDay === "number" &&
+          Number.isFinite(data.activeDay)
+        ) {
           routineState.$jazz.set("activeDay", data.activeDay);
         }
       } catch {
@@ -1977,6 +1982,10 @@ function SyncPanel({ color }: { color: string }) {
                   onChange={(e) => setLoginPhrase(e.target.value)}
                   placeholder="Escribe aquí tu frase de recuperación"
                   rows={3}
+                  spellCheck={false}
+                  autoCorrect="off"
+                  autoCapitalize="off"
+                  autoComplete="off"
                   style={{
                     fontFamily: "'Barlow', sans-serif",
                     fontSize: 13,

--- a/src/components/Workout/schema/Workout.ts
+++ b/src/components/Workout/schema/Workout.ts
@@ -1,0 +1,101 @@
+import { co, z } from "jazz-tools";
+
+// ─── JAZZ SCHEMA ─────────────────────────────────────────────────────────────
+// Synced workout state. Mirrors the data that used to live in localStorage:
+//   completed:    map of exerciseId -> number of completed sets
+//   weekHistory:  timestamps of completed weeks
+//   activeDay:    currently selected day within the routine
+
+export const CompletedSets = co.record(z.string(), z.number());
+export const WeekHistory = co.list(z.number());
+
+export const RoutineState = co.map({
+  activeDay: z.number(),
+  completed: CompletedSets,
+  weekHistory: WeekHistory,
+});
+
+// Keyed by routine id ("a" | "b" | "c").
+export const RoutineStates = co.record(z.string(), RoutineState);
+
+export const WorkoutRoot = co.map({
+  activeRoutineId: z.string(),
+  routines: RoutineStates,
+});
+
+export const WorkoutAccount = co
+  .account({
+    profile: co.profile(),
+    root: WorkoutRoot,
+  })
+  .withMigration((account) => {
+    if (!account.$jazz.has("root")) {
+      account.$jazz.set(
+        "root",
+        WorkoutRoot.create({
+          activeRoutineId: "c",
+          routines: RoutineStates.create({}),
+        }),
+      );
+    }
+  });
+
+// ─── LOCALSTORAGE MIGRATION ──────────────────────────────────────────────────
+// The tracker previously persisted per-routine state under `workout-<id>-*`
+// keys (with un-namespaced fallbacks for the original routine "a"). When a
+// routine has no synced state yet, we seed it from those keys.
+
+export type RoutineSeed = {
+  activeDay: number;
+  completed: Record<string, number>;
+  weekHistory: number[];
+};
+
+export function createRoutineState(seed: RoutineSeed) {
+  return RoutineState.create({
+    activeDay: seed.activeDay,
+    completed: CompletedSets.create(seed.completed),
+    weekHistory: WeekHistory.create(seed.weekHistory),
+  });
+}
+
+function safeGet(key: string): string | null {
+  try {
+    return localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function parseJSON<T>(raw: string | null, fallback: T): T {
+  if (!raw) return fallback;
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+export function legacyRoutineId(): string | null {
+  return safeGet("workout-routine");
+}
+
+export function loadLegacyRoutine(rid: string): RoutineSeed {
+  // Routine "a" predates the per-routine namespace, so fall back to the
+  // original un-namespaced keys.
+  const oldKey = (suffix: string) =>
+    rid === "a" ? safeGet(`workout-${suffix}`) : null;
+
+  const completedRaw =
+    safeGet(`workout-${rid}-completed`) ?? oldKey("completed");
+  const activeDayRaw =
+    safeGet(`workout-${rid}-active-day`) ?? oldKey("active-day");
+  const weekHistoryRaw =
+    safeGet(`workout-${rid}-week-history`) ?? oldKey("week-history");
+
+  return {
+    activeDay: activeDayRaw ? Number(activeDayRaw) || 0 : 0,
+    completed: parseJSON<Record<string, number>>(completedRaw, {}),
+    weekHistory: parseJSON<number[]>(weekHistoryRaw, []),
+  };
+}


### PR DESCRIPTION
## Summary

The workout tracker previously stored all progress in `localStorage`, so each device kept its own separate state. This wires it up to [Jazz](https://jazz.tools/) so progress syncs across devices.

- **Jazz schema** (`src/components/Workout/schema/Workout.ts`): a `WorkoutAccount` whose root holds per-routine state (`activeDay`, `completed` set map, `weekHistory`). The tracker now reads/writes these CoValues instead of `localStorage`.
- **Automatic migration**: on first load, existing `localStorage` data (including the original un-namespaced routine "a" keys) is seeded into the synced account.
- **Device pairing via passphrase**: a new "Sincronización" panel lets the user enable sync — it generates a Spanish recovery phrase to save, and entering that phrase on another device shares the same account. Sync is opt-in; until enabled, data stays local to the device (persisted via Jazz's local storage).

## Notes

- New dependency: `@scure/bip39` (recovery-phrase wordlist).
- The page stays a `client:only` React island; no SSR involved.
- Export/import JSON backup still works against the synced state.

## Test plan

- [x] `pnpm run check` — 0 errors
- [x] `pnpm run build` — succeeds
- [x] Workout page renders; routines, days and exercises intact
- [x] Marking sets updates progress and persists across reload (Jazz local storage)
- [x] "Activar sincronización" signs the account up and reveals the recovery phrase
- [ ] Verify real cross-device sync against `cloud.jazz.tools` (the sandbox env intercepts TLS, so the sync WebSocket can't be validated here — needs a check in a normal browser)


---
_Generated by [Claude Code](https://claude.ai/code/session_01PG3auViUJiiczbqQbcBkxs)_