### PR TITLE
Add routines from the app via validated JSON

### DIFF
--- a/.claude/skills/workout-routine-json/SKILL.md
+++ b/.claude/skills/workout-routine-json/SKILL.md
@@ -1,0 +1,207 @@
+---
+name: workout-routine-json
+description: >-
+  Convert a workout/training routine described in natural language (in any
+  language) into the exact JSON the Workout Tracker app accepts when you paste a
+  routine in the "AÑADIR RUTINA" panel. Use this whenever the user provides a
+  routine as text, a photo/screenshot description, a PDF, or a spreadsheet dump
+  and wants it turned into importable JSON. The skill documents the full schema,
+  every validation rule, and — importantly — which training concepts are and are
+  NOT representable, so you can tell the user what was dropped.
+---
+
+# Workout routine → JSON
+
+The Workout Tracker (`/workout`) lets you add a custom routine by pasting a JSON
+object. That JSON is validated with a strict Effect schema
+(`src/components/Workout/schema/routine.ts`): if anything is wrong it is
+rejected with an explicit error. Your job is to produce JSON that validates on
+the first try, and to be honest with the user about anything in their routine
+that this format cannot express.
+
+## Golden rules
+
+1. **Output only one JSON object**, matching the schema below. No comments, no
+   trailing commas, no markdown fences inside the value the user will paste.
+2. **Every id must be unique** across the whole routine (exercise ids, superset
+   `pairedId`s, and weekly-exercise ids all share one namespace).
+3. **Pick a routine `id` that is not** `a`, `b`, `c`, or `d` — those are
+   reserved for the built-in routines. Use a short slug, e.g. `"fuerza-2026"`.
+4. **After giving the JSON, list what could not be represented** (see
+   "Unsupported concepts"). Never silently drop information like weights, RPE,
+   tempo, or a periodization scheme — the user must know it was left out.
+5. If the user's routine is ambiguous or missing required data (e.g. no rep
+   count), ask a brief clarifying question or state the assumption you made.
+
+## Schema reference
+
+Top level (`Routine`):
+
+| Field             | Type                | Required | Rules |
+|-------------------|---------------------|----------|-------|
+| `id`              | string              | yes      | Non-empty, unique slug, **not** `a`/`b`/`c`/`d` |
+| `name`            | string              | yes      | Non-empty. Convention: UPPERCASE, e.g. `"RUTINA FUERZA"` |
+| `workoutData`     | `WorkoutDay[]`      | yes      | At least 1 day |
+| `weeklyExercises` | `WeeklyExercise[]`  | no       | Defaults to `[]` |
+| `notes`           | `string[]`          | no       | Defaults to `[]`. Free text lines |
+
+`WorkoutDay`:
+
+| Field      | Type              | Required | Rules |
+|------------|-------------------|----------|-------|
+| `id`       | integer           | yes      | Whole number. Convention: `1, 2, 3…` |
+| `label`    | string            | yes      | Non-empty. Short, e.g. `"DÍA 1"` |
+| `title`    | string            | yes      | Non-empty. Focus of the day, e.g. `"ESPALDA"` |
+| `color`    | string            | yes      | Hex color `#RGB` or `#RRGGBB`, e.g. `"#00E5FF"` |
+| `restNote` | string            | yes      | May be empty `""`. Short rest hint, e.g. `"1' entre series"` |
+| `groups`   | `ExerciseGroup[]` | yes      | At least 1 group |
+
+`ExerciseGroup`:
+
+| Field       | Type         | Required | Rules |
+|-------------|--------------|----------|-------|
+| `name`      | string       | yes      | Non-empty. Muscle group, e.g. `"PECHO"` |
+| `supersets` | boolean      | yes      | `true` if the exercises in this group are supersets |
+| `exercises` | `Exercise[]` | yes      | At least 1 exercise |
+
+`Exercise`:
+
+| Field        | Type    | Required | Rules |
+|--------------|---------|----------|-------|
+| `id`         | string  | yes      | Non-empty, unique |
+| `name`       | string  | yes      | Non-empty |
+| `sets`       | integer | yes      | Whole number **> 0** |
+| `reps`       | string  | yes      | Non-empty **text**: `"12"`, `"8-10"`, `"FALLO"`, `"20 seg"` |
+| `pairedWith` | string  | no*      | Superset: name of the paired exercise |
+| `pairedId`   | string  | no*      | Superset: unique id of the paired exercise |
+| `repsB`      | string  | no*      | Superset: reps of the paired exercise |
+
+\* The three `paired*` fields form a superset and must appear **together or not
+at all**. Providing only one or two is rejected. When you use them, also set the
+group's `supersets` to `true`.
+
+`WeeklyExercise` (things done N times per week, not tied to a day):
+
+| Field          | Type    | Required | Rules |
+|----------------|---------|----------|-------|
+| `id`           | string  | yes      | Non-empty, unique |
+| `name`         | string  | yes      | Non-empty |
+| `sets`         | integer | yes      | Whole number > 0 |
+| `reps`         | string  | yes      | Non-empty text |
+| `timesPerWeek` | integer | yes      | Whole number > 0 |
+
+### Notes on field semantics
+
+- **`reps` is always a string.** Encode ranges (`"8-10"`), failure (`"FALLO"`),
+  time (`"30 seg"`), or per-side notes here. Do not use a number.
+- **`sets` is always a whole number.** If the routine says "3-4 series", pick
+  one (e.g. 4) and mention the assumption, or fold the range into a note.
+- **Colors**: give each day a distinct accent. A usable palette:
+  `#00E5FF`, `#FFD600`, `#FF6B6B`, `#7CFFB2`, `#B388FF`, `#FF9E40`.
+- **Ids**: a simple, collision-free scheme is `d<day>-<n>` for day exercises
+  (`d1-1`, `d1-2`), `d1-1b` for the paired half of a superset, and `w-<n>` for
+  weekly exercises.
+
+## Supported concepts (safe to convert)
+
+- Multiple training days, each with a title/focus and a color.
+- Grouping exercises by muscle group within a day.
+- Number of sets (whole number) and reps as free text.
+- **2-exercise supersets** via the `paired*` trio.
+- Weekly/accessory work done a fixed number of times per week.
+- A short per-day rest hint (`restNote`) and free-text routine `notes`.
+
+## Unsupported concepts — tell the user
+
+These have **no structured field**. Do not invent fields for them. Either fold
+them into `reps`/`name`/`notes` as plain text, or omit them — and in both cases
+**explicitly tell the user** what happened:
+
+- **Weight / load / %1RM / RPE / RIR** — no weight field. Put in `notes` or the
+  exercise `reps` text (e.g. `"8 @RPE8"`) if the user wants, otherwise dropped.
+- **Structured rest timers per exercise** — the app has a fixed rest timer; only
+  a per-day `restNote` text exists. Encode rest as text, not structure.
+- **Tempo / cadence** (e.g. `3-1-1`) — no field; fold into `reps`/`name` or drop.
+- **Tri-sets / giant sets (3+ exercises)** — only 2-exercise supersets exist.
+  Split into separate exercises (and note it) or represent only a pair.
+- **Drop sets / rest-pause / cluster sets** — no structure; describe in `reps`
+  or `notes`.
+- **Week-by-week periodization / progression** — the routine is flat (one set of
+  days). Capture progression only as `notes`, not as separate weeks.
+- **Cardio/conditioning blocks** — no dedicated type. Represent as an exercise
+  with `reps` as duration text, or as a `note`.
+- **Mapping days to specific weekdays** (Mon/Wed/Fri) — days are just labeled
+  `DÍA 1…N`; there is no calendar. Mention the intended schedule in `notes`.
+- **Images, videos, external links.**
+
+## Validation checklist (run before returning)
+
+- [ ] Valid JSON, single object, no comments/trailing commas.
+- [ ] `id` is a non-empty slug and not `a`/`b`/`c`/`d`.
+- [ ] `name` non-empty.
+- [ ] `workoutData` has ≥ 1 day; each day has ≥ 1 group; each group has ≥ 1 exercise.
+- [ ] Every `color` is a valid hex color.
+- [ ] Every `sets`/`timesPerWeek` is a whole number > 0; every `reps` is non-empty text.
+- [ ] All ids unique across days, superset pairs, and weekly exercises.
+- [ ] Supersets use all three `paired*` fields and the group's `supersets: true`.
+- [ ] You have listed for the user anything from their routine you could not encode.
+
+## Worked example
+
+User: *"Rutina de fuerza. Día 1 empuje: press banca 4x8 y press inclinado 3x10.
+Superserie de tríceps: extensiones 3x12 con fondos 3x al fallo. Abdominales 3x15
+dos veces por semana. Sube el peso cada semana."*
+
+Output JSON:
+
+```json
+{
+  "id": "fuerza-2026",
+  "name": "RUTINA FUERZA",
+  "workoutData": [
+    {
+      "id": 1,
+      "label": "DÍA 1",
+      "title": "EMPUJE",
+      "color": "#00E5FF",
+      "restNote": "90\" entre series",
+      "groups": [
+        {
+          "name": "PECHO",
+          "supersets": false,
+          "exercises": [
+            { "id": "d1-1", "name": "PRESS BANCA", "sets": 4, "reps": "8" },
+            { "id": "d1-2", "name": "PRESS INCLINADO", "sets": 3, "reps": "10" }
+          ]
+        },
+        {
+          "name": "TRÍCEPS",
+          "supersets": true,
+          "exercises": [
+            {
+              "id": "d1-3",
+              "name": "EXTENSIONES",
+              "sets": 3,
+              "reps": "12",
+              "pairedWith": "FONDOS",
+              "pairedId": "d1-3b",
+              "repsB": "FALLO"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "weeklyExercises": [
+    { "id": "w-1", "name": "ABDOMINALES", "sets": 3, "reps": "15", "timesPerWeek": 2 }
+  ],
+  "notes": ["Subir el peso cada semana (progresión no representable como estructura)."]
+}
+```
+
+Then tell the user, for example:
+
+> Convertido. Nota: la progresión semanal de peso no tiene un campo propio en la
+> app, la he dejado como nota. El `restNote` "90\"" es orientativo; el
+> temporizador de descanso de la app es fijo. Si quieres registrar cargas o RPE,
+> dímelo y las añado al texto de las repeticiones o a las notas.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "start": "astro dev",
     "build": "astro check && astro build",
     "check": "astro check",
+    "test": "vitest run",
     "preview": "astro build && astro preview",
     "astro": "astro",
     "generate-pdf": "node scripts/generate-cv-pdf.mjs",
@@ -38,7 +39,8 @@
     "@tailwindcss/typography": "^0.5.15",
     "@types/node": "^24.0.7",
     "@webgpu/types": "^0.1.70",
-    "playwright": "^1.55.1"
+    "playwright": "^1.55.1",
+    "vitest": "^4.1.10"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "astro": "6.1.6",
     "astro-expressive-code": "^0.42.0",
     "astro-robots-txt": "1.0.0",
+    "effect": "^3.21.4",
     "jazz-tools": "^0.20.18",
     "lucide-react": "0.559.0",
     "motion": "11.18.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       astro-robots-txt:
         specifier: 1.0.0
         version: 1.0.0
+      effect:
+        specifier: ^3.21.4
+        version: 3.21.4
       jazz-tools:
         specifier: ^0.20.18
         version: 0.20.18(csstype@3.2.3)(react-dom@19.2.4(react@19.2.4))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.11)(react@19.2.4))(react@19.2.4)(sharp@0.34.5)
@@ -881,6 +884,9 @@ packages:
   '@sinclair/typebox@0.27.10':
     resolution: {integrity: sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@tailwindcss/node@4.1.18':
     resolution: {integrity: sha512-DoR7U1P7iYhw16qJ49fgXUlry1t4CpXeErJHnQ44JgTSKMaZUdf17cfn5mHchfJ4KRBZRFA/Coo+MUF5+gOaCQ==}
 
@@ -1476,6 +1482,9 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
+  effect@3.21.4:
+    resolution: {integrity: sha512-B89v/xSgPbl1J2Ai2u18jxq3odpFauU1rC6/eSs4FeNHi72kwKdJp12VGigvRV2lK+kRnx+OOz41XV8guZd4gQ==}
+
   electron-to-chromium@1.5.140:
     resolution: {integrity: sha512-o82Rj+ONp4Ip7Cl1r7lrqx/pXhbp/lh9DpKcMNscFJdh8ebyRofnc7Sh01B4jx403RI0oqTBvlZ7OBIZLMr2+Q==}
 
@@ -1553,6 +1562,10 @@ packages:
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
+  fast-check@3.23.2:
+    resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
+    engines: {node: '>=8.0.0'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -2488,6 +2501,9 @@ packages:
 
   prosemirror-view@1.41.8:
     resolution: {integrity: sha512-TnKDdohEatgyZNGCDWIdccOHXhYloJwbwU+phw/a23KBvJIR9lWQWW7WHHK3vBdOLDNuF7TaX98GObUZOWkOnA==}
+
+  pure-rand@6.1.0:
+    resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
   queue@6.0.2:
     resolution: {integrity: sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==}
@@ -3950,6 +3966,8 @@ snapshots:
 
   '@sinclair/typebox@0.27.10': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@tailwindcss/node@4.1.18':
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -4619,6 +4637,11 @@ snapshots:
 
   ee-first@1.1.1: {}
 
+  effect@3.21.4:
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      fast-check: 3.23.2
+
   electron-to-chromium@1.5.140: {}
 
   emmet@2.4.11:
@@ -4702,6 +4725,10 @@ snapshots:
       '@expressive-code/plugin-text-markers': 0.42.0
 
   extend@3.0.2: {}
+
+  fast-check@3.23.2:
+    dependencies:
+      pure-rand: 6.1.0
 
   fast-deep-equal@3.1.3: {}
 
@@ -5937,6 +5964,8 @@ snapshots:
       prosemirror-model: 1.25.4
       prosemirror-state: 1.4.4
       prosemirror-transform: 1.12.0
+
+  pure-rand@6.1.0: {}
 
   queue@6.0.2:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       playwright:
         specifier: ^1.55.1
         version: 1.55.1
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@24.0.7)(vite@7.3.2(@types/node@24.0.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.47.1)(yaml@2.8.3))
 
 packages:
 
@@ -1006,8 +1009,14 @@ packages:
   '@types/babel__traverse@7.20.7':
     resolution: {integrity: sha512-dkO5fhS7+/oos4ciWxyEyjWe48zmG6wbCheo/G2ZnHx4fs3EU6YC6UM8rk56gAjNJ9P3MTH2jo5jb92/K6wbng==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -1061,6 +1070,35 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
 
   '@volar/kit@2.4.28':
     resolution: {integrity: sha512-cKX4vK9dtZvDRaAzeoUdaAJEew6IdxHNCRrdp5Kvcl6zZOqb6jTOfk3kXkIkG3T7oTFXguEMt5+9ptyqYR84Pg==}
@@ -1151,6 +1189,10 @@ packages:
   asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   astro-expressive-code@0.42.0:
     resolution: {integrity: sha512-aiTePi2Cn0mJPYWZSzP1GcxCinX9mNtJyCCshVVPSg1yRwM7ADvFJOx0FnS440M9t65hp8JH//dc2qr22Bm4ag==}
     peerDependencies:
@@ -1207,6 +1249,10 @@ packages:
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -1543,6 +1589,9 @@ packages:
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
@@ -1553,6 +1602,10 @@ packages:
 
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   exponential-backoff@3.1.3:
     resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
@@ -2393,6 +2446,9 @@ packages:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
   piccolore@0.1.3:
     resolution: {integrity: sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw==}
 
@@ -2693,6 +2749,9 @@ packages:
     resolution: {integrity: sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ==}
     engines: {node: '>=20'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
@@ -2718,6 +2777,9 @@ packages:
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   stackframe@1.3.4:
     resolution: {integrity: sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==}
 
@@ -2732,6 +2794,9 @@ packages:
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
+
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -2775,6 +2840,9 @@ packages:
   tiny-inflate@1.0.3:
     resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyclip@0.1.12:
     resolution: {integrity: sha512-Ae3OVUqifDw0wBriIBS7yVaW44Dp6eSHQcyq4Igc7eN2TJH/2YsicswaW+J/OuMvhpDPOKEgpAZCjkb4hpoyeA==}
     engines: {node: ^16.14.0 || >= 17.3.0}
@@ -2790,6 +2858,10 @@ packages:
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   tmpl@1.0.5:
     resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
@@ -3044,6 +3116,47 @@ packages:
       vite:
         optional: true
 
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   vlq@1.0.1:
     resolution: {integrity: sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==}
 
@@ -3158,6 +3271,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   wrap-ansi@7.0.0:
@@ -4084,9 +4202,16 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
 
@@ -4147,6 +4272,47 @@ snapshots:
       vite: 7.3.2(@types/node@24.0.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.47.1)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
+
+  '@vitest/expect@4.1.10':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.10(vite@7.3.2(@types/node@24.0.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.47.1)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.2(@types/node@24.0.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.47.1)(yaml@2.8.3)
+
+  '@vitest/pretty-format@4.1.10':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.10':
+    dependencies:
+      '@vitest/utils': 4.1.10
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.10': {}
+
+  '@vitest/utils@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   '@volar/kit@2.4.28(typescript@5.9.3)':
     dependencies:
@@ -4246,6 +4412,8 @@ snapshots:
   array-iterate@2.0.1: {}
 
   asap@2.0.6: {}
+
+  assertion-error@2.0.1: {}
 
   astro-expressive-code@0.42.0(astro@6.1.6(@types/node@24.0.7)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.60.2)(terser@5.47.1)(typescript@5.9.3)(yaml@2.8.3)):
     dependencies:
@@ -4386,6 +4554,8 @@ snapshots:
   caniuse-lite@1.0.30001715: {}
 
   ccount@2.0.1: {}
+
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -4709,11 +4879,17 @@ snapshots:
 
   estree-walker@2.0.2: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   etag@1.8.1: {}
 
   event-target-shim@5.0.1: {}
 
   eventemitter3@5.0.4: {}
+
+  expect-type@1.4.0: {}
 
   exponential-backoff@3.1.3: {}
 
@@ -5815,6 +5991,8 @@ snapshots:
 
   path-key@3.1.1: {}
 
+  pathe@2.0.3: {}
+
   piccolore@0.1.3: {}
 
   picocolors@1.1.1: {}
@@ -6284,6 +6462,8 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 
+  siginfo@2.0.0: {}
+
   sisteransi@1.0.5: {}
 
   smol-toml@1.6.1: {}
@@ -6301,6 +6481,8 @@ snapshots:
 
   space-separated-tokens@2.0.2: {}
 
+  stackback@0.0.2: {}
+
   stackframe@1.3.4: {}
 
   stacktrace-parser@0.1.11:
@@ -6310,6 +6492,8 @@ snapshots:
   statuses@1.5.0: {}
 
   statuses@2.0.2: {}
+
+  std-env@4.2.0: {}
 
   string-width@4.2.3:
     dependencies:
@@ -6359,6 +6543,8 @@ snapshots:
 
   tiny-inflate@1.0.3: {}
 
+  tinybench@2.9.0: {}
+
   tinyclip@0.1.12: {}
 
   tinyest@0.3.2: {}
@@ -6369,6 +6555,8 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
 
   tmpl@1.0.5: {}
 
@@ -6544,6 +6732,34 @@ snapshots:
     optionalDependencies:
       vite: 7.3.2(@types/node@24.0.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.47.1)(yaml@2.8.3)
 
+  vitest@4.1.10(@opentelemetry/api@1.9.0)(@types/node@24.0.7)(vite@7.3.2(@types/node@24.0.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.47.1)(yaml@2.8.3)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@7.3.2(@types/node@24.0.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.47.1)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.0.0
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 7.3.2(@types/node@24.0.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.47.1)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      '@types/node': 24.0.7
+    transitivePeerDependencies:
+      - msw
+
   vlq@1.0.1: {}
 
   volar-service-css@0.0.70(@volar/language-service@2.4.28):
@@ -6658,6 +6874,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   wrap-ansi@7.0.0:
     dependencies:

--- a/src/components/Workout/WorkoutApp.tsx
+++ b/src/components/Workout/WorkoutApp.tsx
@@ -1378,6 +1378,8 @@ function WorkoutTracker() {
   const [routineJson, setRoutineJson] = useState("");
   const [routineErrors, setRoutineErrors] = useState<string[]>([]);
   const [routineSuccess, setRoutineSuccess] = useState<string | null>(null);
+  // Inline "delete routine" confirmation for the active custom routine.
+  const [confirmDeleteRoutine, setConfirmDeleteRoutine] = useState(false);
 
   // Re-runs when the active account changes (e.g. after logging in with a
   // recovery phrase), so a freshly switched-to account is seeded too.
@@ -1448,7 +1450,10 @@ function WorkoutTracker() {
       );
     }
     appRoot.$jazz.set("activeRoutineId", newId);
+    setConfirmDeleteRoutine(false);
   };
+
+  const isCustomRoutine = customRoutines.some((r) => r.id === activeRoutineId);
 
   const readCustomRoutines = (): Record<string, unknown> => {
     try {
@@ -1684,22 +1689,93 @@ function WorkoutTracker() {
               <span style={{ color: day.color }}>{day.title}</span>
             </div>
           </div>
-          <button
-            onClick={resetDay}
-            style={{
-              fontFamily: "'Barlow Condensed', sans-serif",
-              fontSize: 11,
-              letterSpacing: "0.1em",
-              color: "#444",
-              background: "transparent",
-              border: "1px solid #222",
-              borderRadius: 6,
-              padding: "6px 10px",
-              cursor: "pointer",
-            }}
-          >
-            RESET
-          </button>
+          <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+            {isCustomRoutine &&
+              (confirmDeleteRoutine ? (
+                <>
+                  <span
+                    style={{
+                      fontFamily: "'Barlow Condensed', sans-serif",
+                      fontSize: 11,
+                      letterSpacing: "0.08em",
+                      color: "#FF6B6B",
+                      textTransform: "uppercase",
+                    }}
+                  >
+                    ¿Borrar rutina?
+                  </span>
+                  <button
+                    onClick={() => {
+                      deleteCustomRoutine(activeRoutineId);
+                      setConfirmDeleteRoutine(false);
+                    }}
+                    style={{
+                      fontFamily: "'Barlow Condensed', sans-serif",
+                      fontSize: 11,
+                      fontWeight: 700,
+                      letterSpacing: "0.1em",
+                      color: "#0a0a0a",
+                      background: "#FF6B6B",
+                      border: "none",
+                      borderRadius: 6,
+                      padding: "6px 10px",
+                      cursor: "pointer",
+                    }}
+                  >
+                    SÍ
+                  </button>
+                  <button
+                    onClick={() => setConfirmDeleteRoutine(false)}
+                    style={{
+                      fontFamily: "'Barlow Condensed', sans-serif",
+                      fontSize: 11,
+                      letterSpacing: "0.1em",
+                      color: "#888",
+                      background: "transparent",
+                      border: "1px solid #333",
+                      borderRadius: 6,
+                      padding: "6px 10px",
+                      cursor: "pointer",
+                    }}
+                  >
+                    NO
+                  </button>
+                </>
+              ) : (
+                <button
+                  onClick={() => setConfirmDeleteRoutine(true)}
+                  style={{
+                    fontFamily: "'Barlow Condensed', sans-serif",
+                    fontSize: 11,
+                    letterSpacing: "0.1em",
+                    color: "#FF6B6B",
+                    background: "transparent",
+                    border: "1px solid #FF6B6B33",
+                    borderRadius: 6,
+                    padding: "6px 10px",
+                    cursor: "pointer",
+                  }}
+                >
+                  BORRAR
+                </button>
+              ))}
+            <button
+              onClick={resetDay}
+              style={{
+                fontFamily: "'Barlow Condensed', sans-serif",
+                fontSize: 11,
+                letterSpacing: "0.1em",
+                color: "#444",
+                background: "transparent",
+                border: "1px solid #222",
+                borderRadius: 6,
+                padding: "6px 10px",
+                cursor: "pointer",
+              }}
+            >
+              RESET
+            </button>
+          </div>
         </div>
 
         {/* Progress bar */}
@@ -2198,8 +2274,6 @@ function WorkoutTracker() {
           setRoutineErrors([]);
           setRoutineSuccess(null);
         }}
-        customRoutines={customRoutines}
-        onDelete={deleteCustomRoutine}
       />
 
       {/* Sync */}
@@ -2229,8 +2303,6 @@ function AddRoutinePanel({
   success,
   onSubmit,
   onFillExample,
-  customRoutines,
-  onDelete,
 }: {
   color: string;
   open: boolean;
@@ -2241,8 +2313,6 @@ function AddRoutinePanel({
   success: string | null;
   onSubmit: () => void;
   onFillExample: () => void;
-  customRoutines: WorkoutRoutine[];
-  onDelete: (id: string) => void;
 }) {
   const labelStyle: CSSProperties = {
     fontFamily: "'Barlow Condensed', sans-serif",
@@ -2392,61 +2462,6 @@ function AddRoutinePanel({
                   </li>
                 ))}
               </ul>
-            </div>
-          )}
-
-          {customRoutines.length > 0 && (
-            <div style={{ marginTop: 16 }}>
-              <div style={{ ...labelStyle, color: "#444", marginBottom: 8 }}>
-                RUTINAS PERSONALIZADAS
-              </div>
-              {customRoutines.map((r) => (
-                <div
-                  key={r.id}
-                  style={{
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "space-between",
-                    padding: "8px 12px",
-                    background: "#111",
-                    border: "1px solid #222",
-                    borderRadius: 6,
-                    marginBottom: 6,
-                  }}
-                >
-                  <span
-                    style={{
-                      fontFamily: "'Barlow Condensed', sans-serif",
-                      fontSize: 13,
-                      color: "#ccc",
-                      letterSpacing: "0.06em",
-                    }}
-                  >
-                    {r.name}
-                  </span>
-                  <button
-                    onClick={() => {
-                      if (
-                        confirm(`¿Borrar la rutina "${r.name}"? Esta acción no se puede deshacer.`)
-                      )
-                        onDelete(r.id);
-                    }}
-                    style={{
-                      fontFamily: "'Barlow Condensed', sans-serif",
-                      fontSize: 11,
-                      letterSpacing: "0.1em",
-                      color: "#FF6B6B",
-                      background: "transparent",
-                      border: "1px solid #FF6B6B33",
-                      borderRadius: 6,
-                      padding: "4px 10px",
-                      cursor: "pointer",
-                    }}
-                  >
-                    BORRAR
-                  </button>
-                </div>
-              ))}
             </div>
           )}
         </div>

--- a/src/components/Workout/WorkoutApp.tsx
+++ b/src/components/Workout/WorkoutApp.tsx
@@ -17,6 +17,11 @@ import {
   legacyRoutineId,
   loadLegacyRoutine,
 } from "./schema/Workout";
+import {
+  decodeRoutine,
+  parseRoutineJson,
+  type DecodedRoutine,
+} from "./schema/routine";
 
 const SYNC_PEER =
   "wss://cloud.jazz.tools/?key=workout-tracker@danielo515.github.io";
@@ -795,6 +800,100 @@ const routines: WorkoutRoutine[] = [
   },
 ];
 
+// ─── CUSTOM ROUTINES ─────────────────────────────────────────────────────────
+// Routines added from the app are validated with the Effect schema and stored
+// (as JSON) in the Jazz root. `adaptRoutine` turns the decoded value into the
+// runtime `WorkoutRoutine` shape used throughout the tracker, normalizing the
+// optional superset fields into the `BaseExercise | SuperSetExercise` union.
+
+function adaptRoutine(r: DecodedRoutine): WorkoutRoutine {
+  return {
+    id: r.id,
+    name: r.name,
+    workoutData: r.workoutData.map((d) => ({
+      id: d.id,
+      label: d.label,
+      title: d.title,
+      color: d.color,
+      restNote: d.restNote,
+      groups: d.groups.map((g) => ({
+        name: g.name,
+        supersets: g.supersets,
+        exercises: g.exercises.map((e): Exercise =>
+          e.pairedWith !== undefined &&
+          e.pairedId !== undefined &&
+          e.repsB !== undefined
+            ? {
+                id: e.id,
+                name: e.name,
+                sets: e.sets,
+                reps: e.reps,
+                pairedWith: e.pairedWith,
+                pairedId: e.pairedId,
+                repsB: e.repsB,
+              }
+            : { id: e.id, name: e.name, sets: e.sets, reps: e.reps },
+        ),
+      })),
+    })),
+    weeklyExercises: r.weeklyExercises.map((e) => ({
+      id: e.id,
+      name: e.name,
+      sets: e.sets,
+      reps: e.reps,
+      timesPerWeek: e.timesPerWeek,
+    })),
+    notes: [...r.notes],
+  };
+}
+
+// Decode the JSON object stored in Jazz into ready-to-render routines, skipping
+// any entry that no longer validates (e.g. saved before a schema change).
+function loadCustomRoutines(raw: string | undefined): WorkoutRoutine[] {
+  if (!raw) return [];
+  let map: unknown;
+  try {
+    map = JSON.parse(raw);
+  } catch {
+    return [];
+  }
+  if (!map || typeof map !== "object") return [];
+  const result: WorkoutRoutine[] = [];
+  for (const value of Object.values(map as Record<string, unknown>)) {
+    const decoded = decodeRoutine(value);
+    if (decoded.ok) result.push(adaptRoutine(decoded.routine));
+  }
+  return result;
+}
+
+const ROUTINE_JSON_EXAMPLE = `{
+  "id": "fuerza-2026",
+  "name": "RUTINA FUERZA",
+  "workoutData": [
+    {
+      "id": 1,
+      "label": "DÍA 1",
+      "title": "EMPUJE",
+      "color": "#00E5FF",
+      "restNote": "90\\" entre series",
+      "groups": [
+        {
+          "name": "PECHO",
+          "supersets": false,
+          "exercises": [
+            { "id": "d1-1", "name": "PRESS BANCA", "sets": 4, "reps": "8" },
+            { "id": "d1-2", "name": "PRESS INCLINADO", "sets": 3, "reps": "10" }
+          ]
+        }
+      ]
+    }
+  ],
+  "weeklyExercises": [
+    { "id": "w-1", "name": "ABDOMINALES", "sets": 3, "reps": "15", "timesPerWeek": 2 }
+  ],
+  "notes": ["Progresa el peso cada semana"]
+}`;
+
 // ─── TIMER HOOK ──────────────────────────────────────────────────────────────
 
 async function postToSW(msg: Record<string, unknown>) {
@@ -1274,6 +1373,12 @@ function WorkoutTracker() {
   const { secondsLeft, running, start, stop } = useRestTimer();
   const fileInputRef = useRef<HTMLInputElement>(null);
 
+  // "Add routine" panel state.
+  const [showAddRoutine, setShowAddRoutine] = useState(false);
+  const [routineJson, setRoutineJson] = useState("");
+  const [routineErrors, setRoutineErrors] = useState<string[]>([]);
+  const [routineSuccess, setRoutineSuccess] = useState<string | null>(null);
+
   // Re-runs when the active account changes (e.g. after logging in with a
   // recovery phrase), so a freshly switched-to account is seeded too.
   const accountId = me.$isLoaded ? me.$jazz.id : null;
@@ -1287,6 +1392,10 @@ function WorkoutTracker() {
       if (!root.routines.$jazz.has(rid)) {
         root.routines.$jazz.set(rid, createRoutineState(loadLegacyRoutine(rid)));
       }
+    }
+    // Seed the custom-routines store for accounts created before it existed.
+    if (!root.$jazz.has("customRoutinesJson")) {
+      root.$jazz.set("customRoutinesJson", "{}");
     }
     if (wasEmpty) {
       const legacy = legacyRoutineId();
@@ -1310,8 +1419,14 @@ function WorkoutTracker() {
   const routineState = appRoot.routines[activeRoutineId];
   if (!routineState?.$isLoaded) return <LoadingScreen />;
 
+  const customRoutinesRaw = appRoot.$jazz.has("customRoutinesJson")
+    ? appRoot.customRoutinesJson
+    : "{}";
+  const customRoutines = loadCustomRoutines(customRoutinesRaw);
+  const allRoutines = [...routines, ...customRoutines];
+
   const routine =
-    routines.find((r) => r.id === activeRoutineId) ??
+    allRoutines.find((r) => r.id === activeRoutineId) ??
     routines[routines.length - 1]!;
   const workoutData = routine.workoutData;
   const weeklyExercises = routine.weeklyExercises;
@@ -1333,6 +1448,54 @@ function WorkoutTracker() {
       );
     }
     appRoot.$jazz.set("activeRoutineId", newId);
+  };
+
+  const readCustomRoutines = (): Record<string, unknown> => {
+    try {
+      const parsed = JSON.parse(customRoutinesRaw || "{}");
+      return parsed && typeof parsed === "object" ? parsed : {};
+    } catch {
+      return {};
+    }
+  };
+
+  const addRoutineFromJson = () => {
+    const result = parseRoutineJson(routineJson);
+    if (!result.ok) {
+      setRoutineErrors(result.errors);
+      setRoutineSuccess(null);
+      return;
+    }
+    const { routine: parsed } = result;
+    if (routines.some((r) => r.id === parsed.id)) {
+      setRoutineErrors([
+        `Ya existe una rutina integrada con el id "${parsed.id}". Usa un id distinto.`,
+      ]);
+      setRoutineSuccess(null);
+      return;
+    }
+    const map = readCustomRoutines();
+    const isUpdate = parsed.id in map;
+    map[parsed.id] = parsed;
+    appRoot.$jazz.set("customRoutinesJson", JSON.stringify(map));
+    switchRoutine(parsed.id);
+    setRoutineErrors([]);
+    setRoutineJson("");
+    setShowAddRoutine(false);
+    setRoutineSuccess(
+      isUpdate
+        ? `Rutina "${parsed.name}" actualizada.`
+        : `Rutina "${parsed.name}" añadida.`,
+    );
+  };
+
+  const deleteCustomRoutine = (id: string) => {
+    const map = readCustomRoutines();
+    if (!(id in map)) return;
+    delete map[id];
+    appRoot.$jazz.set("customRoutinesJson", JSON.stringify(map));
+    if (activeRoutineId === id)
+      appRoot.$jazz.set("activeRoutineId", routines[routines.length - 1]!.id);
   };
 
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -1454,7 +1617,7 @@ function WorkoutTracker() {
           borderBottom: "1px solid #1a1a1a",
         }}
       >
-        {routines.map((r) => (
+        {allRoutines.map((r) => (
           <button
             key={r.id}
             onClick={() => switchRoutine(r.id)}
@@ -2014,6 +2177,31 @@ function WorkoutTracker() {
         </button>
       </div>
 
+      {/* Add routine */}
+      <AddRoutinePanel
+        color={day.color}
+        open={showAddRoutine}
+        onToggle={() => {
+          setShowAddRoutine((v) => !v);
+          setRoutineErrors([]);
+        }}
+        json={routineJson}
+        onJsonChange={(value) => {
+          setRoutineJson(value);
+          setRoutineSuccess(null);
+        }}
+        errors={routineErrors}
+        success={routineSuccess}
+        onSubmit={addRoutineFromJson}
+        onFillExample={() => {
+          setRoutineJson(ROUTINE_JSON_EXAMPLE);
+          setRoutineErrors([]);
+          setRoutineSuccess(null);
+        }}
+        customRoutines={customRoutines}
+        onDelete={deleteCustomRoutine}
+      />
+
       {/* Sync */}
       <SyncPanel color={day.color} />
 
@@ -2025,6 +2213,244 @@ function WorkoutTracker() {
         onStop={stop}
         color={day.color}
       />
+    </div>
+  );
+}
+
+// ─── ADD ROUTINE PANEL ───────────────────────────────────────────────────────
+
+function AddRoutinePanel({
+  color,
+  open,
+  onToggle,
+  json,
+  onJsonChange,
+  errors,
+  success,
+  onSubmit,
+  onFillExample,
+  customRoutines,
+  onDelete,
+}: {
+  color: string;
+  open: boolean;
+  onToggle: () => void;
+  json: string;
+  onJsonChange: (value: string) => void;
+  errors: string[];
+  success: string | null;
+  onSubmit: () => void;
+  onFillExample: () => void;
+  customRoutines: WorkoutRoutine[];
+  onDelete: (id: string) => void;
+}) {
+  const labelStyle: CSSProperties = {
+    fontFamily: "'Barlow Condensed', sans-serif",
+    fontSize: 12,
+    fontWeight: 700,
+    letterSpacing: "0.08em",
+    textTransform: "uppercase",
+  };
+
+  return (
+    <div style={{ padding: "16px 20px 0" }}>
+      <button
+        onClick={onToggle}
+        style={{
+          ...labelStyle,
+          width: "100%",
+          padding: "10px 14px",
+          background: open ? "#1a1a1a" : "transparent",
+          color: open ? "#fff" : "#888",
+          border: `1px solid ${open ? color + "55" : "#333"}`,
+          borderRadius: 6,
+          cursor: "pointer",
+        }}
+      >
+        {open ? "× CERRAR" : "+ AÑADIR RUTINA"}
+      </button>
+
+      {success && !open && (
+        <div
+          style={{
+            ...labelStyle,
+            marginTop: 10,
+            padding: "8px 12px",
+            color: "#7CFFB2",
+            background: "#7CFFB211",
+            border: "1px solid #7CFFB233",
+            borderRadius: 6,
+          }}
+        >
+          {success}
+        </div>
+      )}
+
+      {open && (
+        <div style={{ marginTop: 12 }}>
+          <div
+            style={{
+              fontFamily: "'Barlow Condensed', sans-serif",
+              fontSize: 12,
+              color: "#666",
+              lineHeight: 1.5,
+              marginBottom: 8,
+            }}
+          >
+            Pega el JSON de la rutina y pulsa validar. Si algo está mal, verás
+            exactamente qué campo falla y por qué.
+          </div>
+
+          <textarea
+            value={json}
+            onChange={(e) => onJsonChange(e.target.value)}
+            placeholder="Pega aquí el JSON de la rutina…"
+            spellCheck={false}
+            rows={10}
+            style={{
+              width: "100%",
+              fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+              fontSize: 12,
+              lineHeight: 1.5,
+              color: "#ddd",
+              background: "#111",
+              border: `1px solid ${errors.length ? "#FF6B6B55" : "#333"}`,
+              borderRadius: 6,
+              padding: "10px 12px",
+              resize: "vertical",
+              outline: "none",
+              boxSizing: "border-box",
+            }}
+          />
+
+          <div style={{ display: "flex", gap: 10, marginTop: 10 }}>
+            <button
+              onClick={onSubmit}
+              style={{
+                ...labelStyle,
+                flex: 1,
+                padding: "10px 14px",
+                background: color,
+                color: "#0a0a0a",
+                border: "none",
+                borderRadius: 6,
+                cursor: "pointer",
+              }}
+            >
+              VALIDAR Y AÑADIR
+            </button>
+            <button
+              onClick={onFillExample}
+              style={{
+                ...labelStyle,
+                padding: "10px 14px",
+                background: "#1a1a1a",
+                color: "#888",
+                border: "1px solid #333",
+                borderRadius: 6,
+                cursor: "pointer",
+              }}
+            >
+              VER EJEMPLO
+            </button>
+          </div>
+
+          {errors.length > 0 && (
+            <div
+              style={{
+                marginTop: 12,
+                padding: "10px 14px",
+                background: "#FF6B6B0d",
+                border: "1px solid #FF6B6B44",
+                borderRadius: 6,
+              }}
+            >
+              <div
+                style={{
+                  ...labelStyle,
+                  color: "#FF6B6B",
+                  marginBottom: 8,
+                }}
+              >
+                {errors.length === 1
+                  ? "1 ERROR ENCONTRADO"
+                  : `${errors.length} ERRORES ENCONTRADOS`}
+              </div>
+              <ul style={{ margin: 0, paddingLeft: 18 }}>
+                {errors.map((err, i) => (
+                  <li
+                    key={i}
+                    style={{
+                      fontFamily: "'Barlow', sans-serif",
+                      fontSize: 12,
+                      color: "#ffb3b3",
+                      lineHeight: 1.5,
+                      marginBottom: 4,
+                    }}
+                  >
+                    {err}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {customRoutines.length > 0 && (
+            <div style={{ marginTop: 16 }}>
+              <div style={{ ...labelStyle, color: "#444", marginBottom: 8 }}>
+                RUTINAS PERSONALIZADAS
+              </div>
+              {customRoutines.map((r) => (
+                <div
+                  key={r.id}
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "space-between",
+                    padding: "8px 12px",
+                    background: "#111",
+                    border: "1px solid #222",
+                    borderRadius: 6,
+                    marginBottom: 6,
+                  }}
+                >
+                  <span
+                    style={{
+                      fontFamily: "'Barlow Condensed', sans-serif",
+                      fontSize: 13,
+                      color: "#ccc",
+                      letterSpacing: "0.06em",
+                    }}
+                  >
+                    {r.name}
+                  </span>
+                  <button
+                    onClick={() => {
+                      if (
+                        confirm(`¿Borrar la rutina "${r.name}"? Esta acción no se puede deshacer.`)
+                      )
+                        onDelete(r.id);
+                    }}
+                    style={{
+                      fontFamily: "'Barlow Condensed', sans-serif",
+                      fontSize: 11,
+                      letterSpacing: "0.1em",
+                      color: "#FF6B6B",
+                      background: "transparent",
+                      border: "1px solid #FF6B6B33",
+                      borderRadius: 6,
+                      padding: "4px 10px",
+                      cursor: "pointer",
+                    }}
+                  >
+                    BORRAR
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/Workout/WorkoutApp.tsx
+++ b/src/components/Workout/WorkoutApp.tsx
@@ -21,6 +21,7 @@ import {
   decodeRoutine,
   parseRoutineJson,
   type DecodedRoutine,
+  type DecodedExercise,
 } from "./schema/routine";
 
 const SYNC_PEER =
@@ -806,64 +807,55 @@ const routines: WorkoutRoutine[] = [
 // runtime `WorkoutRoutine` shape used throughout the tracker, normalizing the
 // optional superset fields into the `BaseExercise | SuperSetExercise` union.
 
+// The decoded exercise carries the superset fields as optionals; collapse them
+// into the runtime `BaseExercise | SuperSetExercise` union (all three or none).
+function adaptExercise(e: DecodedExercise): Exercise {
+  return e.pairedWith !== undefined &&
+    e.pairedId !== undefined &&
+    e.repsB !== undefined
+    ? {
+        id: e.id,
+        name: e.name,
+        sets: e.sets,
+        reps: e.reps,
+        pairedWith: e.pairedWith,
+        pairedId: e.pairedId,
+        repsB: e.repsB,
+      }
+    : { id: e.id, name: e.name, sets: e.sets, reps: e.reps };
+}
+
 function adaptRoutine(r: DecodedRoutine): WorkoutRoutine {
   return {
     id: r.id,
     name: r.name,
     workoutData: r.workoutData.map((d) => ({
-      id: d.id,
-      label: d.label,
-      title: d.title,
-      color: d.color,
-      restNote: d.restNote,
-      groups: d.groups.map((g) => ({
-        name: g.name,
-        supersets: g.supersets,
-        exercises: g.exercises.map((e): Exercise =>
-          e.pairedWith !== undefined &&
-          e.pairedId !== undefined &&
-          e.repsB !== undefined
-            ? {
-                id: e.id,
-                name: e.name,
-                sets: e.sets,
-                reps: e.reps,
-                pairedWith: e.pairedWith,
-                pairedId: e.pairedId,
-                repsB: e.repsB,
-              }
-            : { id: e.id, name: e.name, sets: e.sets, reps: e.reps },
-        ),
-      })),
+      ...d,
+      groups: d.groups.map((g) => ({ ...g, exercises: g.exercises.map(adaptExercise) })),
     })),
-    weeklyExercises: r.weeklyExercises.map((e) => ({
-      id: e.id,
-      name: e.name,
-      sets: e.sets,
-      reps: e.reps,
-      timesPerWeek: e.timesPerWeek,
-    })),
+    weeklyExercises: r.weeklyExercises.map((e) => ({ ...e })),
     notes: [...r.notes],
   };
 }
 
-// Decode the JSON object stored in Jazz into ready-to-render routines, skipping
-// any entry that no longer validates (e.g. saved before a schema change).
-function loadCustomRoutines(raw: string | undefined): WorkoutRoutine[] {
-  if (!raw) return [];
-  let map: unknown;
+// Parse the JSON object stored in Jazz (id -> routine) into a plain record.
+function parseRoutinesMap(raw: string | undefined): Record<string, unknown> {
+  if (!raw) return {};
   try {
-    map = JSON.parse(raw);
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" ? parsed : {};
   } catch {
-    return [];
+    return {};
   }
-  if (!map || typeof map !== "object") return [];
-  const result: WorkoutRoutine[] = [];
-  for (const value of Object.values(map as Record<string, unknown>)) {
+}
+
+// Decode the stored routines into ready-to-render values, skipping any entry
+// that no longer validates (e.g. saved before a schema change).
+function loadCustomRoutines(raw: string | undefined): WorkoutRoutine[] {
+  return Object.values(parseRoutinesMap(raw)).flatMap((value) => {
     const decoded = decodeRoutine(value);
-    if (decoded.ok) result.push(adaptRoutine(decoded.routine));
-  }
-  return result;
+    return decoded.ok ? [adaptRoutine(decoded.routine)] : [];
+  });
 }
 
 const ROUTINE_JSON_EXAMPLE = `{
@@ -1455,15 +1447,6 @@ function WorkoutTracker() {
 
   const isCustomRoutine = customRoutines.some((r) => r.id === activeRoutineId);
 
-  const readCustomRoutines = (): Record<string, unknown> => {
-    try {
-      const parsed = JSON.parse(customRoutinesRaw || "{}");
-      return parsed && typeof parsed === "object" ? parsed : {};
-    } catch {
-      return {};
-    }
-  };
-
   const addRoutineFromJson = () => {
     const result = parseRoutineJson(routineJson);
     if (!result.ok) {
@@ -1479,7 +1462,7 @@ function WorkoutTracker() {
       setRoutineSuccess(null);
       return;
     }
-    const map = readCustomRoutines();
+    const map = parseRoutinesMap(customRoutinesRaw);
     const isUpdate = parsed.id in map;
     map[parsed.id] = parsed;
     appRoot.$jazz.set("customRoutinesJson", JSON.stringify(map));
@@ -1495,12 +1478,13 @@ function WorkoutTracker() {
   };
 
   const deleteCustomRoutine = (id: string) => {
-    const map = readCustomRoutines();
+    const map = parseRoutinesMap(customRoutinesRaw);
     if (!(id in map)) return;
     delete map[id];
     appRoot.$jazz.set("customRoutinesJson", JSON.stringify(map));
-    if (activeRoutineId === id)
-      appRoot.$jazz.set("activeRoutineId", routines[routines.length - 1]!.id);
+    const fallback = routines[routines.length - 1];
+    if (activeRoutineId === id && fallback)
+      appRoot.$jazz.set("activeRoutineId", fallback.id);
   };
 
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/src/components/Workout/schema/Workout.ts
+++ b/src/components/Workout/schema/Workout.ts
@@ -21,6 +21,10 @@ export const RoutineStates = co.record(z.string(), RoutineState);
 export const WorkoutRoot = co.map({
   activeRoutineId: z.string(),
   routines: RoutineStates,
+  // Custom routines added from the app, serialized as a JSON object keyed by
+  // routine id. Each value is a routine validated with the Effect schema in
+  // `./routine`. Stored as a string to keep the Jazz schema flat and resilient.
+  customRoutinesJson: z.string(),
 });
 
 export const WorkoutAccount = co
@@ -35,6 +39,7 @@ export const WorkoutAccount = co
         WorkoutRoot.create({
           activeRoutineId: "d",
           routines: RoutineStates.create({}),
+          customRoutinesJson: "{}",
         }),
       );
     }

--- a/src/components/Workout/schema/routine.test.ts
+++ b/src/components/Workout/schema/routine.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect } from "vitest";
+import { parseRoutineJson, decodeRoutine } from "./routine";
+
+// Compositional builders: each returns a plain JSON object with sensible
+// defaults that can be overridden per test. Kept loosely typed on purpose —
+// the schema receives `unknown` and these are the inputs under test.
+type Json = Record<string, unknown>;
+
+const exercise = (o: Json = {}): Json => ({
+  id: "d1-1",
+  name: "PRESS BANCA",
+  sets: 4,
+  reps: "8",
+  ...o,
+});
+
+const group = (o: Json = {}): Json => ({
+  name: "PECHO",
+  supersets: false,
+  exercises: [exercise()],
+  ...o,
+});
+
+const day = (o: Json = {}): Json => ({
+  id: 1,
+  label: "DÍA 1",
+  title: "EMPUJE",
+  color: "#00E5FF",
+  restNote: '90" entre series',
+  groups: [group()],
+  ...o,
+});
+
+const routine = (o: Json = {}): Json => ({
+  id: "fuerza-2026",
+  name: "RUTINA FUERZA",
+  workoutData: [day()],
+  weeklyExercises: [],
+  notes: [],
+  ...o,
+});
+
+const errorsOf = (value: unknown): string[] => {
+  const result = decodeRoutine(value);
+  if (result.ok) throw new Error("expected decoding to fail but it succeeded");
+  return result.errors;
+};
+
+describe("parseRoutineJson", () => {
+  it("accepts a valid routine", () => {
+    const result = parseRoutineJson(JSON.stringify(routine()));
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.routine.id).toBe("fuerza-2026");
+      expect(result.routine.workoutData).toHaveLength(1);
+    }
+  });
+
+  it("defaults weeklyExercises and notes to empty arrays when omitted", () => {
+    const result = decodeRoutine({
+      id: "fuerza-2026",
+      name: "RUTINA FUERZA",
+      workoutData: [day()],
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.routine.weeklyExercises).toEqual([]);
+      expect(result.routine.notes).toEqual([]);
+    }
+  });
+
+  it("accepts a valid superset (all three paired fields)", () => {
+    const supersetGroup = group({
+      supersets: true,
+      exercises: [
+        exercise({ pairedWith: "FONDOS", pairedId: "d1-1b", repsB: "FALLO" }),
+      ],
+    });
+    const result = decodeRoutine(
+      routine({ workoutData: [day({ groups: [supersetGroup] })] }),
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  it("reports an explicit error for empty input", () => {
+    const result = parseRoutineJson("   ");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.errors[0]).toContain("Pega el JSON");
+  });
+
+  it("reports an explicit error for non-JSON text", () => {
+    const result = parseRoutineJson("esto no es json {");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.errors[0]).toContain("no es JSON válido");
+  });
+});
+
+describe("decodeRoutine validation errors", () => {
+  it("rejects an empty name", () => {
+    expect(errorsOf(routine({ name: "" })).join("\n")).toContain(
+      "no puede estar vacío",
+    );
+  });
+
+  it("rejects a reserved routine id", () => {
+    expect(errorsOf(routine({ id: "a" })).join("\n")).toContain("reservado");
+  });
+
+  it("rejects sets that are not greater than 0", () => {
+    const broken = routine({
+      workoutData: [day({ groups: [group({ exercises: [exercise({ sets: 0 })] })] })],
+    });
+    expect(errorsOf(broken).join("\n")).toContain("debe ser mayor que 0");
+  });
+
+  it("rejects non-integer sets", () => {
+    const broken = routine({
+      workoutData: [day({ groups: [group({ exercises: [exercise({ sets: 2.5 })] })] })],
+    });
+    expect(errorsOf(broken).join("\n")).toContain("entero");
+  });
+
+  it("rejects an invalid hex color", () => {
+    expect(
+      errorsOf(routine({ workoutData: [day({ color: "azul" })] })).join("\n"),
+    ).toContain("hexadecimal");
+  });
+
+  it("rejects a day with no groups", () => {
+    expect(
+      errorsOf(routine({ workoutData: [day({ groups: [] })] })).join("\n"),
+    ).toContain("al menos un grupo");
+  });
+
+  it("rejects a routine with no days", () => {
+    expect(errorsOf(routine({ workoutData: [] })).join("\n")).toContain(
+      "al menos un día",
+    );
+  });
+
+  it("rejects duplicate exercise ids", () => {
+    const broken = routine({
+      workoutData: [
+        day({ groups: [group({ exercises: [exercise(), exercise()] })] }),
+      ],
+    });
+    expect(errorsOf(broken).join("\n")).toContain("duplicados");
+  });
+
+  it("rejects a partial superset (only some paired fields)", () => {
+    const broken = routine({
+      workoutData: [
+        day({ groups: [group({ exercises: [exercise({ pairedWith: "FONDOS" })] })] }),
+      ],
+    });
+    expect(errorsOf(broken).join("\n")).toContain("superserie necesita");
+  });
+
+  it("reports the field path in the error", () => {
+    expect(
+      errorsOf(routine({ workoutData: [day({ title: "" })] })).join("\n"),
+    ).toContain("title");
+  });
+
+  it("collects every error at once (errors: all)", () => {
+    const broken = routine({
+      name: "",
+      workoutData: [
+        day({ color: "nope", groups: [group({ exercises: [exercise({ sets: 0 })] })] }),
+      ],
+    });
+    expect(errorsOf(broken).length).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/src/components/Workout/schema/routine.ts
+++ b/src/components/Workout/schema/routine.ts
@@ -2,8 +2,9 @@ import { Schema, ParseResult, Either } from "effect";
 
 // ─── EFFECT SCHEMA: ROUTINE DEFINITION ───────────────────────────────────────
 // Validates a routine pasted as JSON before it is stored. Every constraint
-// carries an explicit Spanish message and every type carries a description so
-// the errors surfaced to the user are easy to understand.
+// carries an explicit Spanish message, and types carry `description` +
+// `examples` annotations so the errors surfaced to the user are easy to
+// understand.
 //
 // The shape mirrors the `WorkoutRoutine` interface used by the tracker:
 //   routine -> workoutData[] (days) -> groups[] -> exercises[]
@@ -12,27 +13,28 @@ import { Schema, ParseResult, Either } from "effect";
 
 // ─── PRIMITIVES ──────────────────────────────────────────────────────────────
 
-const NonEmptyString = Schema.String.pipe(
-  Schema.minLength(1, { message: () => "no puede estar vacío" }),
-);
+// Native non-empty string schema with a Spanish message.
+const NonEmptyString = Schema.NonEmptyString.annotations({
+  message: () => "no puede estar vacío",
+});
 
 const PositiveInt = Schema.Number.pipe(
   Schema.int({ message: () => "debe ser un número entero (sin decimales)" }),
   Schema.positive({ message: () => "debe ser mayor que 0" }),
-).annotations({ description: "Número entero mayor que 0" });
+).annotations({ description: "Número entero mayor que 0", examples: [3, 4] });
 
 const HexColor = Schema.String.pipe(
   Schema.pattern(/^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/, {
-    message: () =>
-      'debe ser un color hexadecimal de 3 o 6 dígitos, p. ej. "#00E5FF"',
+    message: () => "debe ser un color hexadecimal de 3 o 6 dígitos",
   }),
 ).annotations({
-  description: 'Color hexadecimal usado como acento del día, p. ej. "#00E5FF"',
+  description: "Color hexadecimal usado como acento del día",
+  examples: ["#00E5FF", "#FFD600", "#FF6B6B"],
 });
 
 const Reps = NonEmptyString.annotations({
-  description:
-    'Repeticiones como texto: número ("12"), rango ("8-10") o palabra ("FALLO")',
+  description: "Repeticiones como texto: número, rango o palabra",
+  examples: ["12", "8-10", "FALLO", "30 seg"],
 });
 
 // Reserved ids belong to the built-in routines and must not be reused. The app
@@ -46,18 +48,25 @@ const RESERVED_ROUTINE_IDS = ["a", "b", "c", "d"];
 const Exercise = Schema.Struct({
   id: NonEmptyString.annotations({
     description: "Identificador único del ejercicio dentro de la rutina",
+    examples: ["d1-1", "d1-2"],
   }),
-  name: NonEmptyString.annotations({ description: "Nombre del ejercicio" }),
+  name: NonEmptyString.annotations({
+    description: "Nombre del ejercicio",
+    examples: ["PRESS BANCA", "JALÓN AL PECHO"],
+  }),
   sets: PositiveInt.annotations({ description: "Número de series" }),
   reps: Reps,
   pairedWith: Schema.optional(NonEmptyString).annotations({
     description: "Superserie: nombre del segundo ejercicio emparejado",
+    examples: ["FONDOS"],
   }),
   pairedId: Schema.optional(NonEmptyString).annotations({
     description: "Superserie: id único del segundo ejercicio emparejado",
+    examples: ["d1-1b"],
   }),
   repsB: Schema.optional(NonEmptyString).annotations({
     description: "Superserie: repeticiones del segundo ejercicio emparejado",
+    examples: ["10", "FALLO"],
   }),
 })
   .pipe(
@@ -83,7 +92,8 @@ const Exercise = Schema.Struct({
 
 const ExerciseGroup = Schema.Struct({
   name: NonEmptyString.annotations({
-    description: 'Nombre del grupo muscular, p. ej. "ESPALDA"',
+    description: "Nombre del grupo muscular",
+    examples: ["ESPALDA", "PECHO", "PIERNA"],
   }),
   supersets: Schema.Boolean.annotations({
     description: "Indica si el grupo se entrena como superseries",
@@ -100,16 +110,22 @@ const ExerciseGroup = Schema.Struct({
 const WorkoutDay = Schema.Struct({
   id: Schema.Number.pipe(
     Schema.int({ message: () => "debe ser un número entero" }),
-  ).annotations({ description: "Identificador numérico del día" }),
+  ).annotations({
+    description: "Identificador numérico del día",
+    examples: [1, 2, 3],
+  }),
   label: NonEmptyString.annotations({
-    description: 'Etiqueta corta del día, p. ej. "DÍA 1"',
+    description: "Etiqueta corta del día",
+    examples: ["DÍA 1", "DÍA 2"],
   }),
   title: NonEmptyString.annotations({
-    description: 'Título del día, normalmente el foco muscular, p. ej. "ESPALDA"',
+    description: "Título del día, normalmente el foco muscular",
+    examples: ["ESPALDA", "EMPUJE"],
   }),
   color: HexColor,
   restNote: Schema.String.annotations({
-    description: 'Nota de descanso, p. ej. "1\' entre series" (puede ir vacía)',
+    description: "Nota de descanso (puede ir vacía)",
+    examples: ["1' entre series", '90" entre series', ""],
   }),
   groups: Schema.Array(ExerciseGroup).pipe(
     Schema.minItems(1, {
@@ -123,12 +139,14 @@ const WorkoutDay = Schema.Struct({
 const WeeklyExercise = Schema.Struct({
   id: NonEmptyString.annotations({
     description: "Identificador único del ejercicio semanal",
+    examples: ["w-1", "w-2"],
   }),
-  name: NonEmptyString,
+  name: NonEmptyString.annotations({ examples: ["ABDOMINALES"] }),
   sets: PositiveInt,
   reps: Reps,
   timesPerWeek: PositiveInt.annotations({
     description: "Veces por semana que se realiza el ejercicio",
+    examples: [2, 3],
   }),
 }).annotations({ identifier: "EjercicioSemanal" });
 
@@ -145,10 +163,12 @@ const Routine = Schema.Struct({
         : true,
     ),
   ).annotations({
-    description: 'Identificador único de la rutina, p. ej. "fuerza-2026"',
+    description: "Identificador único de la rutina",
+    examples: ["fuerza-2026", "hipertrofia-verano"],
   }),
   name: NonEmptyString.annotations({
-    description: 'Nombre visible de la rutina, p. ej. "RUTINA FUERZA"',
+    description: "Nombre visible de la rutina",
+    examples: ["RUTINA FUERZA"],
   }),
   workoutData: Schema.Array(WorkoutDay).pipe(
     Schema.minItems(1, {
@@ -168,27 +188,23 @@ const Routine = Schema.Struct({
     Schema.filter((routine) => {
       // Every exercise id (including the paired ids of supersets and the
       // weekly exercises) must be unique: completion progress is tracked by id.
-      const ids: string[] = [];
-      for (const day of routine.workoutData) {
-        for (const group of day.groups) {
-          for (const ex of group.exercises) {
-            ids.push(ex.id);
-            if (ex.pairedId !== undefined) ids.push(ex.pairedId);
-          }
-        }
-      }
-      for (const ex of routine.weeklyExercises) ids.push(ex.id);
-
-      const seen = new Set<string>();
-      const dupes = new Set<string>();
-      for (const id of ids) {
-        if (seen.has(id)) dupes.add(id);
-        seen.add(id);
-      }
-      if (dupes.size === 0) return true;
+      const ids = [
+        ...routine.workoutData.flatMap((day) =>
+          day.groups.flatMap((group) =>
+            group.exercises.flatMap((ex) =>
+              ex.pairedId !== undefined ? [ex.id, ex.pairedId] : [ex.id],
+            ),
+          ),
+        ),
+        ...routine.weeklyExercises.map((ex) => ex.id),
+      ];
+      const dupes = [
+        ...new Set(ids.filter((id, index) => ids.indexOf(id) !== index)),
+      ];
+      if (dupes.length === 0) return true;
       return {
         path: [],
-        message: `hay ids de ejercicio duplicados: ${[...dupes]
+        message: `hay ids de ejercicio duplicados: ${dupes
           .map((d) => `"${d}"`)
           .join(", ")}. Cada ejercicio debe tener un id único en toda la rutina`,
       };
@@ -204,6 +220,7 @@ const Routine = Schema.Struct({
 export const RoutineSchema = Routine;
 
 export type DecodedRoutine = Schema.Schema.Type<typeof Routine>;
+export type DecodedExercise = Schema.Schema.Type<typeof Exercise>;
 
 // ─── DECODING ────────────────────────────────────────────────────────────────
 

--- a/src/components/Workout/schema/routine.ts
+++ b/src/components/Workout/schema/routine.ts
@@ -1,0 +1,247 @@
+import { Schema, ParseResult, Either } from "effect";
+
+// ─── EFFECT SCHEMA: ROUTINE DEFINITION ───────────────────────────────────────
+// Validates a routine pasted as JSON before it is stored. Every constraint
+// carries an explicit Spanish message and every type carries a description so
+// the errors surfaced to the user are easy to understand.
+//
+// The shape mirrors the `WorkoutRoutine` interface used by the tracker:
+//   routine -> workoutData[] (days) -> groups[] -> exercises[]
+//             -> weeklyExercises[]
+//             -> notes[]
+
+// ─── PRIMITIVES ──────────────────────────────────────────────────────────────
+
+const NonEmptyString = Schema.String.pipe(
+  Schema.minLength(1, { message: () => "no puede estar vacío" }),
+);
+
+const PositiveInt = Schema.Number.pipe(
+  Schema.int({ message: () => "debe ser un número entero (sin decimales)" }),
+  Schema.positive({ message: () => "debe ser mayor que 0" }),
+).annotations({ description: "Número entero mayor que 0" });
+
+const HexColor = Schema.String.pipe(
+  Schema.pattern(/^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/, {
+    message: () =>
+      'debe ser un color hexadecimal de 3 o 6 dígitos, p. ej. "#00E5FF"',
+  }),
+).annotations({
+  description: 'Color hexadecimal usado como acento del día, p. ej. "#00E5FF"',
+});
+
+const Reps = NonEmptyString.annotations({
+  description:
+    'Repeticiones como texto: número ("12"), rango ("8-10") o palabra ("FALLO")',
+});
+
+// Reserved ids belong to the built-in routines and must not be reused. The app
+// also re-checks collisions against the live built-in list when adding.
+const RESERVED_ROUTINE_IDS = ["a", "b", "c", "d"];
+
+// ─── EXERCISE ────────────────────────────────────────────────────────────────
+// A normal exercise. It becomes a superset when the three "paired*" fields are
+// provided together; providing only some of them is rejected.
+
+const Exercise = Schema.Struct({
+  id: NonEmptyString.annotations({
+    description: "Identificador único del ejercicio dentro de la rutina",
+  }),
+  name: NonEmptyString.annotations({ description: "Nombre del ejercicio" }),
+  sets: PositiveInt.annotations({ description: "Número de series" }),
+  reps: Reps,
+  pairedWith: Schema.optional(NonEmptyString).annotations({
+    description: "Superserie: nombre del segundo ejercicio emparejado",
+  }),
+  pairedId: Schema.optional(NonEmptyString).annotations({
+    description: "Superserie: id único del segundo ejercicio emparejado",
+  }),
+  repsB: Schema.optional(NonEmptyString).annotations({
+    description: "Superserie: repeticiones del segundo ejercicio emparejado",
+  }),
+})
+  .pipe(
+    Schema.filter((ex) => {
+      const provided = [ex.pairedWith, ex.pairedId, ex.repsB].filter(
+        (v) => v !== undefined,
+      ).length;
+      if (provided === 0 || provided === 3) return true;
+      return {
+        path: [],
+        message:
+          'una superserie necesita los tres campos juntos ("pairedWith", "pairedId" y "repsB"), o ninguno de ellos',
+      };
+    }),
+  )
+  .annotations({
+    identifier: "Ejercicio",
+    description:
+      "Ejercicio individual; opcionalmente una superserie con un segundo ejercicio emparejado",
+  });
+
+// ─── GROUP ───────────────────────────────────────────────────────────────────
+
+const ExerciseGroup = Schema.Struct({
+  name: NonEmptyString.annotations({
+    description: 'Nombre del grupo muscular, p. ej. "ESPALDA"',
+  }),
+  supersets: Schema.Boolean.annotations({
+    description: "Indica si el grupo se entrena como superseries",
+  }),
+  exercises: Schema.Array(Exercise).pipe(
+    Schema.minItems(1, {
+      message: () => "el grupo debe tener al menos un ejercicio",
+    }),
+  ),
+}).annotations({ identifier: "Grupo" });
+
+// ─── DAY ─────────────────────────────────────────────────────────────────────
+
+const WorkoutDay = Schema.Struct({
+  id: Schema.Number.pipe(
+    Schema.int({ message: () => "debe ser un número entero" }),
+  ).annotations({ description: "Identificador numérico del día" }),
+  label: NonEmptyString.annotations({
+    description: 'Etiqueta corta del día, p. ej. "DÍA 1"',
+  }),
+  title: NonEmptyString.annotations({
+    description: 'Título del día, normalmente el foco muscular, p. ej. "ESPALDA"',
+  }),
+  color: HexColor,
+  restNote: Schema.String.annotations({
+    description: 'Nota de descanso, p. ej. "1\' entre series" (puede ir vacía)',
+  }),
+  groups: Schema.Array(ExerciseGroup).pipe(
+    Schema.minItems(1, {
+      message: () => "el día debe tener al menos un grupo de ejercicios",
+    }),
+  ),
+}).annotations({ identifier: "Día" });
+
+// ─── WEEKLY EXERCISE ─────────────────────────────────────────────────────────
+
+const WeeklyExercise = Schema.Struct({
+  id: NonEmptyString.annotations({
+    description: "Identificador único del ejercicio semanal",
+  }),
+  name: NonEmptyString,
+  sets: PositiveInt,
+  reps: Reps,
+  timesPerWeek: PositiveInt.annotations({
+    description: "Veces por semana que se realiza el ejercicio",
+  }),
+}).annotations({ identifier: "EjercicioSemanal" });
+
+// ─── ROUTINE ─────────────────────────────────────────────────────────────────
+
+const Routine = Schema.Struct({
+  id: NonEmptyString.pipe(
+    Schema.filter((id) =>
+      RESERVED_ROUTINE_IDS.includes(id)
+        ? {
+            path: [],
+            message: `el id "${id}" está reservado para las rutinas integradas (${RESERVED_ROUTINE_IDS.join(", ")}); elige otro distinto`,
+          }
+        : true,
+    ),
+  ).annotations({
+    description: 'Identificador único de la rutina, p. ej. "fuerza-2026"',
+  }),
+  name: NonEmptyString.annotations({
+    description: 'Nombre visible de la rutina, p. ej. "RUTINA FUERZA"',
+  }),
+  workoutData: Schema.Array(WorkoutDay).pipe(
+    Schema.minItems(1, {
+      message: () => "la rutina debe tener al menos un día de entrenamiento",
+    }),
+  ),
+  weeklyExercises: Schema.optionalWith(Schema.Array(WeeklyExercise), {
+    default: () => [],
+  }).annotations({
+    description: "Ejercicios que se hacen X veces por semana (opcional)",
+  }),
+  notes: Schema.optionalWith(Schema.Array(Schema.String), {
+    default: () => [],
+  }).annotations({ description: "Notas de la rutina (opcional)" }),
+})
+  .pipe(
+    Schema.filter((routine) => {
+      // Every exercise id (including the paired ids of supersets and the
+      // weekly exercises) must be unique: completion progress is tracked by id.
+      const ids: string[] = [];
+      for (const day of routine.workoutData) {
+        for (const group of day.groups) {
+          for (const ex of group.exercises) {
+            ids.push(ex.id);
+            if (ex.pairedId !== undefined) ids.push(ex.pairedId);
+          }
+        }
+      }
+      for (const ex of routine.weeklyExercises) ids.push(ex.id);
+
+      const seen = new Set<string>();
+      const dupes = new Set<string>();
+      for (const id of ids) {
+        if (seen.has(id)) dupes.add(id);
+        seen.add(id);
+      }
+      if (dupes.size === 0) return true;
+      return {
+        path: [],
+        message: `hay ids de ejercicio duplicados: ${[...dupes]
+          .map((d) => `"${d}"`)
+          .join(", ")}. Cada ejercicio debe tener un id único en toda la rutina`,
+      };
+    }),
+  )
+  .annotations({
+    identifier: "Rutina",
+    title: "Rutina de entrenamiento",
+    description:
+      "Rutina completa: días de entrenamiento, ejercicios semanales y notas",
+  });
+
+export const RoutineSchema = Routine;
+
+export type DecodedRoutine = Schema.Schema.Type<typeof Routine>;
+
+// ─── DECODING ────────────────────────────────────────────────────────────────
+
+export type DecodeResult =
+  | { ok: true; routine: DecodedRoutine }
+  | { ok: false; errors: string[] };
+
+function formatPath(path: ReadonlyArray<PropertyKey>): string {
+  if (path.length === 0) return "(rutina)";
+  return path.map((segment) => String(segment)).join(" → ");
+}
+
+/** Validate an already-parsed value against the routine schema. */
+export function decodeRoutine(value: unknown): DecodeResult {
+  const result = Schema.decodeUnknownEither(Routine, { errors: "all" })(value);
+  if (Either.isRight(result)) return { ok: true, routine: result.right };
+
+  const errors = ParseResult.ArrayFormatter.formatErrorSync(result.left).map(
+    (issue) => `${formatPath(issue.path)}: ${issue.message}`,
+  );
+  return {
+    ok: false,
+    errors: errors.length > 0 ? errors : ["El JSON no es una rutina válida."],
+  };
+}
+
+/** Parse a JSON string and validate it as a routine. */
+export function parseRoutineJson(text: string): DecodeResult {
+  const trimmed = text.trim();
+  if (trimmed.length === 0) {
+    return { ok: false, errors: ["Pega el JSON de la rutina antes de validar."] };
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    return { ok: false, errors: [`El texto no es JSON válido: ${detail}`] };
+  }
+  return decodeRoutine(parsed);
+}


### PR DESCRIPTION
## Qué hace

Añade un panel **"AÑADIR RUTINA"** al workout tracker para crear rutinas desde la propia app, pegando un JSON, en lugar de abrir un PR por cada rutina nueva.

El JSON se valida **completamente** con un **Effect Schema** que usa anotaciones, descripciones y mensajes personalizados, para que los errores sean muy explícitos y fáciles de entender.

## Validación (Effect Schema)

`src/components/Workout/schema/routine.ts`

- Cada error indica **la ruta exacta** del campo y **el motivo**, en español
  (p. ej. `Día → 0 → groups → 0 → exercises → 1 → sets: debe ser mayor que 0`).
- Recopila **todos los errores a la vez** (`errors: "all"`), no solo el primero.
- Reglas validadas:
  - Strings no vacíos, series como entero positivo, color hexadecimal (`#00E5FF`).
  - Superseries: los tres campos `pairedWith` / `pairedId` / `repsB` juntos, o ninguno.
  - **Ids de ejercicio únicos** en toda la rutina (el progreso se trackea por id).
  - Al menos un día, y cada día al menos un grupo con al menos un ejercicio.
  - Ids reservados `a` / `b` / `c` (rutinas integradas) rechazados.
- `weeklyExercises` y `notes` son opcionales (por defecto `[]`).

## Persistencia y UI

- Las rutinas válidas se guardan (como JSON) en el root de **Jazz**
  (`customRoutinesJson`), así que **se sincronizan entre dispositivos**.
- Se renderizan junto a las rutinas integradas en el selector.
- El panel incluye **"VER EJEMPLO"** (rellena un JSON de muestra) y permite
  **borrar** rutinas personalizadas.
- Migración suave: las cuentas existentes inicializan `customRoutinesJson` al cargar.

## Checks

- `pnpm run check` ✅ 0 errores
- `pnpm run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SBW6XJxa4qUkfMDdXswAKN)_