### PR TITLE
Permitir introducir una frase de recuperación con la sincronización activa

### DIFF
--- a/src/components/Workout/WorkoutApp.tsx
+++ b/src/components/Workout/WorkoutApp.tsx
@@ -2189,6 +2189,16 @@ function SyncPanel({ color }: { color: string }) {
             >
               {showPhrase ? "Ocultar frase" : "Ver frase de recuperación"}
             </button>
+            <button
+              type="button"
+              style={ghostBtn}
+              onClick={() => {
+                setShowLogin((v) => !v);
+                setError("");
+              }}
+            >
+              {showLogin ? "Cancelar" : "Entrar con otra frase"}
+            </button>
           </>
         ) : (
           <>
@@ -2215,39 +2225,46 @@ function SyncPanel({ color }: { color: string }) {
             >
               {showLogin ? "Cancelar" : "Ya tengo una frase de recuperación"}
             </button>
-            {showLogin && (
-              <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-                <textarea
-                  value={loginPhrase}
-                  onChange={(e) => setLoginPhrase(e.target.value)}
-                  placeholder="Escribe aquí tu frase de recuperación"
-                  rows={3}
-                  spellCheck={false}
-                  autoCorrect="off"
-                  autoCapitalize="off"
-                  autoComplete="off"
-                  style={{
-                    fontFamily: "'Barlow', sans-serif",
-                    fontSize: 13,
-                    color: "#fff",
-                    background: "#0a0a0a",
-                    border: "1px solid #222",
-                    borderRadius: 6,
-                    padding: "8px 10px",
-                    resize: "vertical",
-                  }}
-                />
-                <button
-                  type="button"
-                  style={primaryBtn}
-                  disabled={busy || !loginPhrase.trim()}
-                  onClick={logIn}
-                >
-                  {busy ? "Entrando…" : "Entrar"}
-                </button>
+          </>
+        )}
+
+        {showLogin && (
+          <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+            {signedIn && (
+              <div style={{ ...bodyText, color: "#666", fontSize: 11 }}>
+                Entrarás con la cuenta de esa frase. El progreso guardado solo
+                en este dispositivo dejará de mostrarse.
               </div>
             )}
-          </>
+            <textarea
+              value={loginPhrase}
+              onChange={(e) => setLoginPhrase(e.target.value)}
+              placeholder="Escribe aquí tu frase de recuperación"
+              rows={3}
+              spellCheck={false}
+              autoCorrect="off"
+              autoCapitalize="off"
+              autoComplete="off"
+              style={{
+                fontFamily: "'Barlow', sans-serif",
+                fontSize: 13,
+                color: "#fff",
+                background: "#0a0a0a",
+                border: "1px solid #222",
+                borderRadius: 6,
+                padding: "8px 10px",
+                resize: "vertical",
+              }}
+            />
+            <button
+              type="button"
+              style={primaryBtn}
+              disabled={busy || !loginPhrase.trim()}
+              onClick={logIn}
+            >
+              {busy ? "Entrando…" : "Entrar"}
+            </button>
+          </div>
         )}
 
         {showPhrase && signedIn && (

--- a/src/components/Workout/WorkoutApp.tsx
+++ b/src/components/Workout/WorkoutApp.tsx
@@ -2138,16 +2138,18 @@ function SyncPanel({ color }: { color: string }) {
     borderRadius: 6,
     cursor: busy ? "default" : "pointer",
   };
-  const ghostBtn: CSSProperties = {
+  const secondaryBtn: CSSProperties = {
     fontFamily: "'Barlow Condensed', sans-serif",
-    fontSize: 11,
+    fontSize: 12,
     fontWeight: 700,
     letterSpacing: "0.08em",
     textTransform: "uppercase",
-    background: "transparent",
-    color: "#666",
-    border: "none",
-    padding: "8px 0 0",
+    width: "100%",
+    padding: "10px 14px",
+    background: color + "18",
+    color,
+    border: `1px solid ${color}55`,
+    borderRadius: 6,
     cursor: "pointer",
   };
 
@@ -2184,16 +2186,20 @@ function SyncPanel({ color }: { color: string }) {
             </div>
             <button
               type="button"
-              style={ghostBtn}
-              onClick={() => setShowPhrase((v) => !v)}
+              style={secondaryBtn}
+              onClick={() => {
+                setShowPhrase((v) => !v);
+                setShowLogin(false);
+              }}
             >
               {showPhrase ? "Ocultar frase" : "Ver frase de recuperación"}
             </button>
             <button
               type="button"
-              style={ghostBtn}
+              style={secondaryBtn}
               onClick={() => {
                 setShowLogin((v) => !v);
+                setShowPhrase(false);
                 setError("");
               }}
             >
@@ -2217,9 +2223,10 @@ function SyncPanel({ color }: { color: string }) {
             </button>
             <button
               type="button"
-              style={ghostBtn}
+              style={secondaryBtn}
               onClick={() => {
                 setShowLogin((v) => !v);
+                setShowPhrase(false);
                 setError("");
               }}
             >


### PR DESCRIPTION
## Problema

En el panel de sincronización del workout tracker se había perdido la capacidad de **introducir** una frase de sincronización. El textarea para "Ya tengo una frase de recuperación" solo se mostraba mientras la cuenta seguía siendo anónima (`state !== "signedIn"`).

Una vez activada la sincronización (`signedIn`), el panel únicamente ofrecía **ver y copiar** la frase, sin ninguna forma de escribir una frase existente para entrar con otra cuenta ya sincronizada desde ese dispositivo.

## Solución

- Se extrae el formulario de login (textarea + botón "Entrar") a un bloque compartido que se muestra en ambos estados según `showLogin`.
- Se añade un botón **"Entrar con otra frase"** en la vista de sincronización activa.
- Cuando ya estás sincronizado, se muestra un aviso de que entrar con otra frase cambiará de cuenta y el progreso guardado solo en el dispositivo dejará de mostrarse.

El hook `usePassphraseAuth` expone `logIn` independientemente del estado, por lo que reutilizar el mismo handler funciona tanto para cuentas anónimas como ya autenticadas.

## Verificación

- `pnpm run check` → 0 errores
- `pnpm run build` → build correcto

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011tQduoQwwPM7KitBt2ZG6K)_