### PR TITLE
feat(blog): editor de entradas 100% cliente con borradores en Jazz

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "astro-robots-txt": "1.0.0",
     "jazz-tools": "^0.20.18",
     "lucide-react": "0.559.0",
+    "marked": "^18.0.10",
     "motion": "11.18.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       lucide-react:
         specifier: 0.559.0
         version: 0.559.0(react@19.2.4)
+      marked:
+        specifier: ^18.0.10
+        version: 18.0.10
       motion:
         specifier: 11.18.2
         version: 11.18.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -2024,6 +2027,11 @@ packages:
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
+  marked@18.0.10:
+    resolution: {integrity: sha512-FJeH4bRpYoXiggcgriCGItKCSv3xkngJc4QCZ/rkQCogU3VYaLxYJoZl8Nw/b4+x7iij/pd+09mZ6A1dXzpL0A==}
+    engines: {node: '>= 20'}
+    hasBin: true
 
   marky@1.3.0:
     resolution: {integrity: sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==}
@@ -5160,6 +5168,8 @@ snapshots:
       tmpl: 1.0.5
 
   markdown-table@3.0.4: {}
+
+  marked@18.0.10: {}
 
   marky@1.3.0: {}
 

--- a/src/components/BlogEditor/BlogEditorApp.tsx
+++ b/src/components/BlogEditor/BlogEditorApp.tsx
@@ -1,0 +1,147 @@
+import { JazzReactProvider, useAccount } from "jazz-tools/react";
+import { FilePlus2, Trash2 } from "lucide-react";
+import { DraftEditor } from "./DraftEditor";
+import { SyncPanel } from "./SyncPanel";
+import {
+  BlogEditorAccount,
+  createDraft,
+  draftTitle,
+  type LoadedBlogDraft,
+} from "./schema/Draft";
+
+const SYNC_PEER =
+  "wss://cloud.jazz.tools/?key=blog-editor@danielo515.github.io";
+
+/**
+ * A fully client-side editor for new blog entries. Nothing is posted to a
+ * backend of mine: drafts live in Jazz (local first, synced when you enable
+ * it) and publishing goes straight from the browser to GitHub.
+ */
+export default function BlogEditorApp({
+  tagSuggestions = [],
+}: {
+  tagSuggestions?: string[];
+}) {
+  return (
+    <JazzReactProvider
+      sync={{ peer: SYNC_PEER }}
+      AccountSchema={BlogEditorAccount}
+      fallback={<Loading />}
+    >
+      <Editor tagSuggestions={tagSuggestions} />
+    </JazzReactProvider>
+  );
+}
+
+function Loading({ message = "Cargando borradores…" }: { message?: string }) {
+  return (
+    <p className="py-16 text-center text-sm text-gray-500 dark:text-gray-400">
+      {message}
+    </p>
+  );
+}
+
+function Editor({ tagSuggestions }: { tagSuggestions: string[] }) {
+  const me = useAccount(BlogEditorAccount, {
+    resolve: { root: { drafts: { $each: { tags: true } } } },
+  });
+
+  if (!me.$isLoaded) {
+    if (me.$jazz.loadingState === "unauthorized")
+      return <Loading message="No tienes acceso a esta cuenta." />;
+    if (me.$jazz.loadingState === "unavailable")
+      return <Loading message="No se pudo cargar tu cuenta." />;
+    return <Loading />;
+  }
+
+  const root = me.root;
+  const drafts = root.drafts;
+
+  const addDraft = () => {
+    const draft = createDraft(drafts.$jazz.owner);
+    drafts.$jazz.push(draft);
+    root.$jazz.set("currentDraftId", draft.$jazz.id);
+  };
+
+  const removeDraft = (draft: LoadedBlogDraft) => {
+    const label = draftTitle(draft);
+    if (!window.confirm(`¿Borrar «${label}»? No se puede deshacer.`)) return;
+    const index = drafts.findIndex(
+      (candidate) => candidate.$jazz.id === draft.$jazz.id,
+    );
+    if (index >= 0) drafts.$jazz.remove(index);
+    if (root.currentDraftId === draft.$jazz.id)
+      root.$jazz.set("currentDraftId", "");
+  };
+
+  // Fall back to the most recent draft when the stored selection points at
+  // something that no longer exists (deleted here or on another device).
+  const current =
+    drafts.find((draft) => draft.$jazz.id === root.currentDraftId) ??
+    drafts[drafts.length - 1];
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex flex-wrap items-center gap-2">
+          {drafts.map((draft) => {
+            const active = draft.$jazz.id === current?.$jazz.id;
+            return (
+              <span
+                key={draft.$jazz.id}
+                className={`inline-flex items-center gap-1 rounded-full border px-3 py-1 text-xs ${
+                  active
+                    ? "border-indigo-400 bg-indigo-50 dark:bg-indigo-900/40 text-indigo-700 dark:text-indigo-200"
+                    : "border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-400"
+                }`}
+              >
+                <button
+                  type="button"
+                  onClick={() =>
+                    root.$jazz.set("currentDraftId", draft.$jazz.id)
+                  }
+                  className="max-w-48 truncate"
+                >
+                  {draftTitle(draft)}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => removeDraft(draft)}
+                  aria-label={`Borrar ${draftTitle(draft)}`}
+                  className="text-gray-400 hover:text-red-600"
+                >
+                  <Trash2 size={12} />
+                </button>
+              </span>
+            );
+          })}
+        </div>
+
+        <button
+          type="button"
+          onClick={addDraft}
+          className="inline-flex items-center gap-2 rounded-md bg-indigo-600 px-3 py-2 text-xs font-semibold text-white hover:bg-indigo-500"
+        >
+          <FilePlus2 size={14} /> Nuevo borrador
+        </button>
+      </div>
+
+      {current ? (
+        <DraftEditor
+          key={current.$jazz.id}
+          draft={current}
+          tagSuggestions={tagSuggestions}
+        />
+      ) : (
+        <div className="rounded-lg border border-dashed border-gray-300 dark:border-gray-600 p-10 text-center">
+          <p className="text-sm text-gray-600 dark:text-gray-400">
+            Todavía no hay ningún borrador. Empieza uno y se irá guardando
+            solo mientras escribes.
+          </p>
+        </div>
+      )}
+
+      <SyncPanel />
+    </div>
+  );
+}

--- a/src/components/BlogEditor/DraftEditor.tsx
+++ b/src/components/BlogEditor/DraftEditor.tsx
@@ -1,0 +1,285 @@
+import { marked } from "marked";
+import { Download, Eye, ImageOff, Pencil } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { buildPublishableFiles } from "@/lib/blogMarkdown";
+import { PublishPanel } from "./PublishPanel";
+import { TagInput } from "./TagInput";
+import { toDraftValues } from "./draftValues";
+import {
+  type LoadedBlogDraft,
+  setDraftCover,
+  setDraftTags,
+  slugify,
+  updateDraftField,
+} from "./schema/Draft";
+
+/** Cover images travel as data URLs inside a CoValue, so keep them small. */
+const MAX_COVER_BYTES = 1_500_000;
+
+const FIELD_CLASS =
+  "w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 px-3 py-2 text-sm text-gray-800 dark:text-gray-100 outline-none focus:border-indigo-500";
+const LABEL_CLASS =
+  "text-xs font-medium text-gray-700 dark:text-gray-300 mb-1 block";
+
+export function DraftEditor({
+  draft,
+  tagSuggestions,
+}: {
+  draft: LoadedBlogDraft;
+  tagSuggestions: string[];
+}) {
+  const [tab, setTab] = useState<"write" | "preview">("write");
+  const [coverError, setCoverError] = useState("");
+  const fileInput = useRef<HTMLInputElement>(null);
+
+  // The slug follows the title until the user edits it by hand, at which
+  // point it is theirs and we stop touching it.
+  const [slugTouched, setSlugTouched] = useState(() => draft.slug !== "");
+  const draftId = draft.$jazz.id;
+  useEffect(() => {
+    setSlugTouched(draft.slug !== "");
+    // Only when switching to a different draft — not on every keystroke.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [draftId]);
+
+  const values = toDraftValues(draft);
+
+  const previewHtml = useMemo(
+    () => marked.parse(values.body || "_Nada que previsualizar todavía._"),
+    [values.body],
+  );
+
+  const onTitleChange = (title: string) => {
+    updateDraftField(draft, "title", title);
+    if (!slugTouched) updateDraftField(draft, "slug", slugify(title));
+  };
+
+  const onCoverPicked = async (file: File | undefined) => {
+    if (!file) return;
+    if (file.size > MAX_COVER_BYTES) {
+      setCoverError(
+        `La imagen ocupa ${(file.size / 1_000_000).toFixed(1)} MB. El máximo es 1,5 MB.`,
+      );
+      return;
+    }
+    setCoverError("");
+    const dataUrl = await new Promise<string>((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(String(reader.result));
+      reader.onerror = () => reject(reader.error);
+      reader.readAsDataURL(file);
+    });
+    setDraftCover(draft, { name: file.name, dataUrl });
+  };
+
+  const download = () => {
+    const built = buildPublishableFiles(values);
+    if (!built.ok) return;
+    const blob = new Blob([built.post.content], {
+      type: "text/markdown;charset=utf-8",
+    });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = `${values.slug}.md`;
+    anchor.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[1fr_20rem] items-start">
+      <div className="flex flex-col gap-4 min-w-0">
+        <div>
+          <label className={LABEL_CLASS} htmlFor="post-title">
+            Título
+          </label>
+          <input
+            id="post-title"
+            value={values.title}
+            onChange={(event) => onTitleChange(event.target.value)}
+            placeholder="El título del artículo"
+            className={FIELD_CLASS}
+          />
+        </div>
+
+        <div>
+          <label className={LABEL_CLASS} htmlFor="post-description">
+            Descripción
+          </label>
+          <textarea
+            id="post-description"
+            value={values.description}
+            onChange={(event) =>
+              updateDraftField(draft, "description", event.target.value)
+            }
+            rows={2}
+            placeholder="Resumen que se ve en la lista del blog y en las redes"
+            className={FIELD_CLASS}
+          />
+        </div>
+
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div>
+            <label className={LABEL_CLASS} htmlFor="post-date">
+              Fecha
+            </label>
+            <input
+              id="post-date"
+              type="date"
+              value={values.date}
+              onChange={(event) =>
+                updateDraftField(draft, "date", event.target.value)
+              }
+              className={FIELD_CLASS}
+            />
+          </div>
+          <div>
+            <label className={LABEL_CLASS} htmlFor="post-slug">
+              Slug (nombre del fichero)
+            </label>
+            <input
+              id="post-slug"
+              value={values.slug}
+              onChange={(event) => {
+                setSlugTouched(true);
+                updateDraftField(draft, "slug", event.target.value);
+              }}
+              placeholder="mi-articulo"
+              className={`${FIELD_CLASS} font-mono text-xs`}
+            />
+          </div>
+        </div>
+
+        <div>
+          <label className={LABEL_CLASS} htmlFor="post-tags">
+            Etiquetas
+          </label>
+          <TagInput
+            id="post-tags"
+            tags={values.tags}
+            suggestions={tagSuggestions}
+            onChange={(tags) => setDraftTags(draft, tags)}
+          />
+        </div>
+
+        <div>
+          <span className={LABEL_CLASS}>Portada (opcional)</span>
+          <div className="flex flex-wrap items-center gap-3">
+            <input
+              ref={fileInput}
+              type="file"
+              accept="image/*"
+              className="hidden"
+              onChange={(event) => void onCoverPicked(event.target.files?.[0])}
+            />
+            <button
+              type="button"
+              onClick={() => fileInput.current?.click()}
+              className="rounded-md border border-gray-300 dark:border-gray-600 px-3 py-1.5 text-xs font-medium text-gray-700 dark:text-gray-200 hover:border-indigo-400"
+            >
+              Elegir imagen
+            </button>
+            {values.coverDataUrl && (
+              <>
+                <img
+                  src={values.coverDataUrl}
+                  alt="Portada elegida"
+                  className="h-12 w-20 rounded object-cover border border-gray-200 dark:border-gray-700"
+                />
+                <button
+                  type="button"
+                  onClick={() => setDraftCover(draft, null)}
+                  className="inline-flex items-center gap-1 text-xs text-red-600 hover:underline"
+                >
+                  <ImageOff size={13} /> Quitar
+                </button>
+              </>
+            )}
+          </div>
+          {coverError && (
+            <p className="mt-1 text-xs text-red-600">{coverError}</p>
+          )}
+        </div>
+
+        <div className="flex flex-col gap-2 min-w-0">
+          <div className="flex items-center justify-between">
+            <span className={LABEL_CLASS}>Contenido (Markdown)</span>
+            <div className="flex gap-1">
+              <TabButton
+                active={tab === "write"}
+                onClick={() => setTab("write")}
+                icon={<Pencil size={12} />}
+                label="Escribir"
+              />
+              <TabButton
+                active={tab === "preview"}
+                onClick={() => setTab("preview")}
+                icon={<Eye size={12} />}
+                label="Vista previa"
+              />
+            </div>
+          </div>
+
+          {tab === "write" ? (
+            <textarea
+              value={values.body}
+              onChange={(event) =>
+                updateDraftField(draft, "body", event.target.value)
+              }
+              rows={22}
+              spellCheck
+              placeholder={"## Un encabezado\n\nY el texto del artículo…"}
+              className={`${FIELD_CLASS} font-mono text-[13px] leading-relaxed resize-y`}
+            />
+          ) : (
+            <article
+              className="prose prose-sm dark:prose-invert max-w-none min-h-96 overflow-x-auto rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 p-4"
+              // The only author of this markdown is the person typing it in
+              // their own browser — there is no second party to protect from.
+              dangerouslySetInnerHTML={{ __html: previewHtml }}
+            />
+          )}
+        </div>
+
+        <button
+          type="button"
+          onClick={download}
+          className="inline-flex items-center gap-2 self-start text-xs text-gray-600 dark:text-gray-400 hover:text-indigo-600 dark:hover:text-indigo-400"
+        >
+          <Download size={13} /> Descargar el .md
+        </button>
+      </div>
+
+      <div className="flex flex-col gap-4 lg:sticky lg:top-6">
+        <PublishPanel draft={values} />
+      </div>
+    </div>
+  );
+}
+
+function TabButton({
+  active,
+  onClick,
+  icon,
+  label,
+}: {
+  active: boolean;
+  onClick: () => void;
+  icon: React.ReactNode;
+  label: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium ${
+        active
+          ? "bg-indigo-100 dark:bg-indigo-900/50 text-indigo-700 dark:text-indigo-300"
+          : "text-gray-600 dark:text-gray-400 hover:text-indigo-600"
+      }`}
+    >
+      {icon}
+      {label}
+    </button>
+  );
+}

--- a/src/components/BlogEditor/PublishPanel.tsx
+++ b/src/components/BlogEditor/PublishPanel.tsx
@@ -3,12 +3,12 @@ import {
   DEFAULT_TARGET,
   GitHubError,
   branchNameFor,
-  prefillFitsInUrl,
+  prefillOverflow,
   prefilledEditorUrl,
   publishViaApi,
 } from "@/lib/github";
 import { AlertTriangle, ExternalLink, GitPullRequest } from "lucide-react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import type { DraftValues } from "./draftValues";
 
 /**
@@ -48,6 +48,14 @@ export function PublishPanel({ draft }: { draft: DraftValues }) {
 
   const built = buildPublishableFiles(draft);
   const canPublish = built.ok;
+  // Binary-searches the real URL, so memoise it rather than redo the search
+  // on every render. Keyed on the built file instead of on `draft`, which is
+  // a fresh object every render and would never hit the cache.
+  const overflow = useMemo(
+    () => prefillOverflow(DEFAULT_TARGET, draft),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [built.ok ? built.post.content : null, built.ok ? built.post.path : null],
+  );
 
   const openPrefilled = () => {
     if (!built.ok) return;
@@ -184,12 +192,16 @@ export function PublishPanel({ draft }: { draft: DraftValues }) {
           Abrir PR en GitHub
         </button>
 
-        {built.ok && !prefillFitsInUrl(DEFAULT_TARGET, built.post) && (
+        {overflow && (
           <p className="flex items-start gap-1.5 text-[11px] text-amber-700 dark:text-amber-400">
             <AlertTriangle size={12} className="mt-0.5 shrink-0" />
-            El artículo es largo y puede que no quepa en la URL. Si GitHub lo
-            abre truncado, descarga el <code>.md</code> y súbelo a mano, o usa
-            un token.
+            <span>
+              El artículo se pasa de largo para caber en la URL: sobran{" "}
+              <strong>
+                {overflow.bodyExcess.toLocaleString("es-ES")} caracteres
+              </strong>
+              . Recórtalo, o publica con token y olvídate del límite.
+            </span>
           </p>
         )}
         {built.ok && built.cover && (

--- a/src/components/BlogEditor/PublishPanel.tsx
+++ b/src/components/BlogEditor/PublishPanel.tsx
@@ -1,0 +1,222 @@
+import { buildPublishableFiles } from "@/lib/blogMarkdown";
+import {
+  DEFAULT_TARGET,
+  GitHubError,
+  branchNameFor,
+  prefillFitsInUrl,
+  prefilledEditorUrl,
+  publishViaApi,
+} from "@/lib/github";
+import { AlertTriangle, ExternalLink, GitPullRequest } from "lucide-react";
+import { useState } from "react";
+import type { DraftValues } from "./draftValues";
+
+/**
+ * The token never goes into Jazz — Jazz syncs to a shared cloud peer, and a
+ * repo-write credential has no business being replicated there. localStorage
+ * on this device only, and only if the user opts in.
+ */
+const TOKEN_KEY = "blog-editor-github-token";
+
+function readToken(): string {
+  try {
+    return localStorage.getItem(TOKEN_KEY) ?? "";
+  } catch {
+    return "";
+  }
+}
+
+function writeToken(token: string) {
+  try {
+    if (token) localStorage.setItem(TOKEN_KEY, token);
+    else localStorage.removeItem(TOKEN_KEY);
+  } catch {
+    /* storage unavailable — the token simply won't be remembered */
+  }
+}
+
+type Status =
+  | { kind: "idle" }
+  | { kind: "working" }
+  | { kind: "done"; url: string; number: number }
+  | { kind: "error"; message: string };
+
+export function PublishPanel({ draft }: { draft: DraftValues }) {
+  const [token, setToken] = useState(readToken);
+  const [remember, setRemember] = useState(() => readToken() !== "");
+  const [status, setStatus] = useState<Status>({ kind: "idle" });
+
+  const built = buildPublishableFiles(draft);
+  const canPublish = built.ok;
+
+  const openPrefilled = () => {
+    if (!built.ok) return;
+    window.open(
+      prefilledEditorUrl(DEFAULT_TARGET, built.post),
+      "_blank",
+      "noopener,noreferrer",
+    );
+  };
+
+  const publish = async () => {
+    if (!built.ok || !token.trim()) return;
+    setStatus({ kind: "working" });
+    writeToken(remember ? token.trim() : "");
+
+    try {
+      const result = await publishViaApi({
+        token: token.trim(),
+        target: DEFAULT_TARGET,
+        post: built.post,
+        cover: built.cover,
+        branch: branchNameFor(draft.slug),
+        commitMessage: `feat(blog): ${draft.title}`,
+        prTitle: `feat(blog): ${draft.title}`,
+        prBody: [
+          draft.description,
+          "",
+          `Nueva entrada del blog escrita desde el editor de \`/blog/new\`.`,
+          "",
+          `- Fichero: \`${built.post.path}\``,
+          `- Fecha: ${draft.date}`,
+          `- Etiquetas: ${draft.tags.join(", ")}`,
+          built.cover ? `- Portada: \`${built.cover.name}\`` : null,
+        ]
+          .filter((line) => line !== null)
+          .join("\n"),
+      });
+      setStatus({ kind: "done", url: result.prUrl, number: result.prNumber });
+    } catch (error) {
+      const message =
+        error instanceof GitHubError
+          ? `GitHub (${error.status}): ${error.message}`
+          : error instanceof Error
+            ? error.message
+            : "Error desconocido al publicar";
+      setStatus({ kind: "error", message });
+    }
+  };
+
+  return (
+    <div className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4 flex flex-col gap-3">
+      <h2 className="text-sm font-semibold text-gray-800 dark:text-white">
+        Publicar
+      </h2>
+
+      {!built.ok && (
+        <ul className="flex flex-col gap-1">
+          {built.errors.map((error) => (
+            <li
+              key={error}
+              className="flex items-start gap-1.5 text-xs text-amber-700 dark:text-amber-400"
+            >
+              <AlertTriangle size={13} className="mt-0.5 shrink-0" />
+              {error}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {built.ok && (
+        <p className="text-xs text-gray-600 dark:text-gray-400">
+          Se creará{" "}
+          <code className="text-[11px] text-gray-800 dark:text-gray-200">
+            {built.post.path}
+          </code>{" "}
+          en una rama nueva sobre{" "}
+          <code className="text-[11px]">{DEFAULT_TARGET.baseBranch}</code>.
+        </p>
+      )}
+
+      <div className="flex flex-col gap-2 border-t border-gray-200 dark:border-gray-700 pt-3">
+        <label className="text-xs font-medium text-gray-700 dark:text-gray-300">
+          Token de GitHub (opcional)
+        </label>
+        <input
+          type="password"
+          value={token}
+          onChange={(event) => setToken(event.target.value)}
+          placeholder="github_pat_…"
+          autoComplete="off"
+          className="rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 px-2 py-1.5 text-xs text-gray-800 dark:text-gray-100"
+        />
+        <label className="flex items-center gap-2 text-[11px] text-gray-600 dark:text-gray-400">
+          <input
+            type="checkbox"
+            checked={remember}
+            onChange={(event) => setRemember(event.target.checked)}
+          />
+          Recordarlo en este navegador
+        </label>
+        <p className="text-[11px] text-gray-500 dark:text-gray-500">
+          Token de acceso <em>fine-grained</em> con permisos de{" "}
+          <strong>Contents</strong> y <strong>Pull requests</strong> sobre{" "}
+          <code className="text-[10px]">
+            {DEFAULT_TARGET.owner}/{DEFAULT_TARGET.repo}
+          </code>
+          . No se sincroniza: se queda en este dispositivo.
+        </p>
+
+        <button
+          type="button"
+          disabled={!canPublish || !token.trim() || status.kind === "working"}
+          onClick={publish}
+          className="inline-flex items-center justify-center gap-2 rounded-md bg-indigo-600 px-3 py-2 text-xs font-semibold text-white hover:bg-indigo-500 disabled:opacity-50"
+        >
+          <GitPullRequest size={14} />
+          {status.kind === "working" ? "Abriendo PR…" : "Crear pull request"}
+        </button>
+      </div>
+
+      <div className="flex flex-col gap-2 border-t border-gray-200 dark:border-gray-700 pt-3">
+        <p className="text-[11px] text-gray-500 dark:text-gray-500">
+          ¿Sin token? Abre el editor de GitHub con el artículo ya escrito y
+          confirma desde ahí con “Create a new branch and start a pull
+          request”.
+        </p>
+        <button
+          type="button"
+          disabled={!canPublish}
+          onClick={openPrefilled}
+          className="inline-flex items-center justify-center gap-2 rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 text-xs font-semibold text-gray-700 dark:text-gray-200 hover:border-indigo-400 disabled:opacity-50"
+        >
+          <ExternalLink size={14} />
+          Abrir PR en GitHub
+        </button>
+
+        {built.ok && !prefillFitsInUrl(DEFAULT_TARGET, built.post) && (
+          <p className="flex items-start gap-1.5 text-[11px] text-amber-700 dark:text-amber-400">
+            <AlertTriangle size={12} className="mt-0.5 shrink-0" />
+            El artículo es largo y puede que no quepa en la URL. Si GitHub lo
+            abre truncado, descarga el <code>.md</code> y súbelo a mano, o usa
+            un token.
+          </p>
+        )}
+        {built.ok && built.cover && (
+          <p className="flex items-start gap-1.5 text-[11px] text-amber-700 dark:text-amber-400">
+            <AlertTriangle size={12} className="mt-0.5 shrink-0" />
+            La portada sólo se sube con token: el editor de GitHub no acepta
+            imágenes por URL.
+          </p>
+        )}
+      </div>
+
+      {status.kind === "done" && (
+        <a
+          href={status.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="rounded-md bg-green-50 dark:bg-green-900/30 p-2 text-xs font-medium text-green-700 dark:text-green-300 hover:underline"
+        >
+          ✓ Pull request #{status.number} creada — ábrela aquí
+        </a>
+      )}
+
+      {status.kind === "error" && (
+        <p className="rounded-md bg-red-50 dark:bg-red-900/30 p-2 text-xs text-red-700 dark:text-red-300">
+          {status.message}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/BlogEditor/SyncPanel.tsx
+++ b/src/components/BlogEditor/SyncPanel.tsx
@@ -1,0 +1,147 @@
+import { wordlist } from "@scure/bip39/wordlists/spanish.js";
+import { usePassphraseAuth } from "jazz-tools/react";
+import { useState } from "react";
+
+/**
+ * Drafts are always stored locally by Jazz; signing up with a passphrase is
+ * what pushes them to the sync server so they survive a wiped browser and
+ * follow you to another device. Same recovery-phrase flow as the workout
+ * tracker.
+ */
+export function SyncPanel() {
+  const auth = usePassphraseAuth({ wordlist });
+  const [showPhrase, setShowPhrase] = useState(false);
+  const [showLogin, setShowLogin] = useState(false);
+  const [loginPhrase, setLoginPhrase] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+  const [copied, setCopied] = useState(false);
+
+  const signedIn = auth.state === "signedIn";
+
+  const enableSync = async () => {
+    setBusy(true);
+    setError("");
+    try {
+      await auth.signUp();
+      setShowPhrase(true);
+    } catch {
+      setError("No se pudo activar la sincronización. Inténtalo de nuevo.");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const logIn = async () => {
+    const phrase = loginPhrase.trim().replace(/\s+/g, " ");
+    if (!phrase) return;
+    setBusy(true);
+    setError("");
+    try {
+      await auth.logIn(phrase);
+      setShowLogin(false);
+      setLoginPhrase("");
+    } catch {
+      setError("La frase no es válida. Revísala e inténtalo de nuevo.");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const copyPhrase = async () => {
+    try {
+      await navigator.clipboard.writeText(auth.passphrase);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      /* clipboard unavailable */
+    }
+  };
+
+  return (
+    <div className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4 flex flex-col gap-3">
+      <h2 className="text-sm font-semibold text-gray-800 dark:text-white">
+        Sincronización
+      </h2>
+
+      {signedIn ? (
+        <>
+          <p className="text-xs text-green-600 dark:text-green-400 font-medium">
+            ✓ Activa — tus borradores se sincronizan entre dispositivos.
+          </p>
+          <button
+            type="button"
+            onClick={() => setShowPhrase((visible) => !visible)}
+            className="text-xs text-indigo-600 dark:text-indigo-400 hover:underline self-start"
+          >
+            {showPhrase ? "Ocultar" : "Ver"} frase de recuperación
+          </button>
+        </>
+      ) : (
+        <>
+          <p className="text-xs text-gray-600 dark:text-gray-400">
+            Los borradores se guardan en este navegador. Activa la
+            sincronización para no perderlos si lo borras o cambias de
+            dispositivo.
+          </p>
+          <button
+            type="button"
+            disabled={busy}
+            onClick={enableSync}
+            className="rounded-md bg-indigo-600 px-3 py-2 text-xs font-semibold text-white hover:bg-indigo-500 disabled:opacity-50"
+          >
+            {busy ? "Activando…" : "Activar sincronización"}
+          </button>
+          <button
+            type="button"
+            onClick={() => setShowLogin((visible) => !visible)}
+            className="text-xs text-indigo-600 dark:text-indigo-400 hover:underline self-start"
+          >
+            Ya tengo una frase de recuperación
+          </button>
+        </>
+      )}
+
+      {showLogin && !signedIn && (
+        <div className="flex flex-col gap-2">
+          <textarea
+            value={loginPhrase}
+            onChange={(event) => setLoginPhrase(event.target.value)}
+            rows={3}
+            placeholder="Escribe aquí tus palabras de recuperación"
+            className="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 px-2 py-1.5 text-xs text-gray-800 dark:text-gray-100"
+          />
+          <button
+            type="button"
+            disabled={busy}
+            onClick={logIn}
+            className="rounded-md bg-indigo-600 px-3 py-2 text-xs font-semibold text-white hover:bg-indigo-500 disabled:opacity-50"
+          >
+            {busy ? "Entrando…" : "Entrar"}
+          </button>
+        </div>
+      )}
+
+      {showPhrase && signedIn && (
+        <div className="flex flex-col gap-2">
+          <p className="rounded-md border border-indigo-300 dark:border-indigo-700 bg-gray-50 dark:bg-gray-900 p-2 text-xs leading-relaxed text-gray-800 dark:text-gray-100">
+            {auth.passphrase}
+          </p>
+          <button
+            type="button"
+            onClick={copyPhrase}
+            className="rounded-md bg-indigo-600 px-3 py-2 text-xs font-semibold text-white hover:bg-indigo-500"
+          >
+            {copied ? "✓ Copiada" : "Copiar frase"}
+          </button>
+          <p className="text-[11px] text-gray-500 dark:text-gray-500">
+            Guárdala en un lugar seguro: es la única forma de recuperar tus
+            borradores desde otro dispositivo.
+          </p>
+        </div>
+      )}
+
+      {error && <p className="text-xs text-red-600">{error}</p>}
+    </div>
+  );
+}

--- a/src/components/BlogEditor/TagInput.tsx
+++ b/src/components/BlogEditor/TagInput.tsx
@@ -1,0 +1,93 @@
+import { X } from "lucide-react";
+import { useState } from "react";
+
+/**
+ * Tags are free-form strings in the blog collection (unlike projects, which
+ * are restricted to the TechTag enum), so this is a plain chip input with
+ * the tags already used across the blog offered as suggestions.
+ */
+export function TagInput({
+  id,
+  tags,
+  suggestions,
+  onChange,
+}: {
+  id: string;
+  tags: string[];
+  suggestions: string[];
+  onChange: (tags: string[]) => void;
+}) {
+  const [pending, setPending] = useState("");
+
+  const add = (raw: string) => {
+    const tag = raw.trim().toLowerCase();
+    if (!tag || tags.includes(tag)) {
+      setPending("");
+      return;
+    }
+    onChange([...tags, tag]);
+    setPending("");
+  };
+
+  const remove = (tag: string) => onChange(tags.filter((t) => t !== tag));
+
+  const unused = suggestions.filter((tag) => !tags.includes(tag)).slice(0, 12);
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex flex-wrap items-center gap-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 px-2 py-2">
+        {tags.map((tag) => (
+          <span
+            key={tag}
+            className="inline-flex items-center gap-1 rounded-full bg-indigo-100 dark:bg-indigo-900/50 px-2.5 py-1 text-xs font-medium text-indigo-800 dark:text-indigo-200"
+          >
+            {tag}
+            <button
+              type="button"
+              onClick={() => remove(tag)}
+              aria-label={`Quitar etiqueta ${tag}`}
+              className="rounded-full hover:bg-indigo-200 dark:hover:bg-indigo-800 p-0.5"
+            >
+              <X size={12} />
+            </button>
+          </span>
+        ))}
+        <input
+          id={id}
+          value={pending}
+          onChange={(event) => setPending(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter" || event.key === ",") {
+              event.preventDefault();
+              add(pending);
+            } else if (
+              event.key === "Backspace" &&
+              pending === "" &&
+              tags.length > 0
+            ) {
+              remove(tags[tags.length - 1]!);
+            }
+          }}
+          onBlur={() => add(pending)}
+          placeholder={tags.length ? "" : "typescript, nix, testing…"}
+          className="flex-1 min-w-32 bg-transparent text-sm outline-none text-gray-800 dark:text-gray-100"
+        />
+      </div>
+
+      {unused.length > 0 && (
+        <div className="flex flex-wrap gap-1.5">
+          {unused.map((tag) => (
+            <button
+              key={tag}
+              type="button"
+              onClick={() => add(tag)}
+              className="rounded-full border border-gray-300 dark:border-gray-600 px-2 py-0.5 text-xs text-gray-600 dark:text-gray-400 hover:border-indigo-400 hover:text-indigo-600 dark:hover:text-indigo-300"
+            >
+              + {tag}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/BlogEditor/draftValues.ts
+++ b/src/components/BlogEditor/draftValues.ts
@@ -1,0 +1,31 @@
+import type { LoadedBlogDraft } from "./schema/Draft";
+
+/**
+ * A draft flattened into plain data. Jazz CoValues are proxies whose fields
+ * may be individually unloaded, which is fine for rendering but awkward for
+ * the pure functions that validate and serialise a post — those take this
+ * instead.
+ */
+export type DraftValues = {
+  slug: string;
+  title: string;
+  description: string;
+  date: string;
+  tags: string[];
+  body: string;
+  coverName: string;
+  coverDataUrl: string;
+};
+
+export function toDraftValues(draft: LoadedBlogDraft): DraftValues {
+  return {
+    slug: draft.slug,
+    title: draft.title,
+    description: draft.description,
+    date: draft.date,
+    tags: draft.tags.$isLoaded ? [...draft.tags] : [],
+    body: draft.body,
+    coverName: draft.coverName,
+    coverDataUrl: draft.coverDataUrl,
+  };
+}

--- a/src/components/BlogEditor/schema/Draft.ts
+++ b/src/components/BlogEditor/schema/Draft.ts
@@ -1,0 +1,133 @@
+import { co, type Group, type Loaded, z } from "jazz-tools";
+
+// ─── JAZZ SCHEMA ─────────────────────────────────────────────────────────────
+// The editor never keeps state only in React: every keystroke lands in a
+// CoValue, so a reload, a crash or a closed tab cannot lose a draft. With
+// sync enabled (passphrase auth) the same drafts follow you across devices.
+//
+// Every field is required with an "empty" value rather than optional — a
+// half-filled draft is the normal state of this app, and optional fields
+// would only push the emptiness into the type system.
+
+export const DraftTags = co.list(z.string());
+export type LoadedDraftTags = Loaded<typeof DraftTags>;
+
+export const BlogDraft = co.map({
+  slug: z.string(),
+  title: z.string(),
+  description: z.string(),
+  /** ISO `yyyy-mm-dd`. Kept as a string because that is exactly what ends
+   *  up in the frontmatter — round-tripping through Date would drag the
+   *  browser timezone into the published date. */
+  date: z.string(),
+  tags: DraftTags,
+  body: z.string(),
+  /** Cover image, inlined as a data URL. Empty string when there is none. */
+  coverName: z.string(),
+  coverDataUrl: z.string(),
+  createdAt: z.date(),
+  updatedAt: z.date(),
+});
+export type LoadedBlogDraft = Loaded<typeof BlogDraft>;
+
+export const BlogDrafts = co.list(BlogDraft);
+export type LoadedBlogDrafts = Loaded<typeof BlogDrafts>;
+
+export const EditorRoot = co.map({
+  drafts: BlogDrafts,
+  /** Jazz id of the draft currently open, or "" when none is selected. */
+  currentDraftId: z.string(),
+});
+
+export const BlogEditorAccount = co
+  .account({
+    profile: co.profile(),
+    root: EditorRoot,
+  })
+  .withMigration((account) => {
+    if (!account.$jazz.has("root")) {
+      account.$jazz.set(
+        "root",
+        EditorRoot.create({
+          drafts: BlogDrafts.create([]),
+          currentDraftId: "",
+        }),
+      );
+    }
+  });
+
+// ─── OPERATIONS ──────────────────────────────────────────────────────────────
+
+export function todayISO(): string {
+  // Local calendar day, not UTC: publishing at 01:00 CET should not date the
+  // post to the previous day.
+  const now = new Date();
+  const offset = now.getTimezoneOffset() * 60_000;
+  return new Date(now.getTime() - offset).toISOString().slice(0, 10);
+}
+
+/**
+ * Turns a title into a filename-safe slug: strips accents, drops anything
+ * that is not a letter or a digit, collapses separators into single dashes.
+ */
+export function slugify(title: string): string {
+  return title
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 80);
+}
+
+export function createDraft(owner: Group) {
+  const now = new Date();
+  return BlogDraft.create(
+    {
+      slug: "",
+      title: "",
+      description: "",
+      date: todayISO(),
+      tags: DraftTags.create([], { owner }),
+      body: "",
+      coverName: "",
+      coverDataUrl: "",
+      createdAt: now,
+      updatedAt: now,
+    },
+    { owner },
+  );
+}
+
+type DraftTextField = "slug" | "title" | "description" | "date" | "body";
+
+export function updateDraftField(
+  draft: LoadedBlogDraft,
+  field: DraftTextField,
+  value: string,
+) {
+  draft.$jazz.set(field, value);
+  draft.$jazz.set("updatedAt", new Date());
+}
+
+export function setDraftCover(
+  draft: LoadedBlogDraft,
+  cover: { name: string; dataUrl: string } | null,
+) {
+  draft.$jazz.set("coverName", cover?.name ?? "");
+  draft.$jazz.set("coverDataUrl", cover?.dataUrl ?? "");
+  draft.$jazz.set("updatedAt", new Date());
+}
+
+export function setDraftTags(draft: LoadedBlogDraft, tags: string[]) {
+  const list = draft.tags;
+  if (!list.$isLoaded) return;
+  // `applyDiff` keeps the CoList identity (and therefore any concurrent
+  // edits from another device) instead of replacing the whole list.
+  list.$jazz.applyDiff(tags);
+  draft.$jazz.set("updatedAt", new Date());
+}
+
+export function draftTitle(draft: LoadedBlogDraft): string {
+  return draft.title.trim() || "Borrador sin título";
+}

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,3 +1,4 @@
+import { blogFrontmatterFields } from "@/lib/blogSchema";
 import { defineCollection } from "astro:content";
 import { glob } from "astro/loaders";
 import { z } from "astro/zod";
@@ -68,13 +69,12 @@ export const collections = {
   }),
   blog: defineCollection({
     loader: glob({ pattern: "**/*.md", base: "./src/content/blog" }),
+    // The non-image fields live in `@/lib/blogSchema` so the client-side
+    // editor at /blog/new validates drafts against this exact shape.
     schema: ({ image }) =>
       z.object({
-        title: z.string(),
-        description: z.string(),
+        ...blogFrontmatterFields,
         image: image().optional(),
-        date: z.date(),
-        tags: z.array(z.string()),
       }),
   }),
 };

--- a/src/lib/blogMarkdown.ts
+++ b/src/lib/blogMarkdown.ts
@@ -116,7 +116,8 @@ export type BuildResult =
   | { ok: true; post: PostFile; cover: CoverImage | null }
   | { ok: false; errors: string[] };
 
-export function buildPublishableFiles(input: {
+/** A draft as the editor holds it, before validation. */
+export type PublishInput = {
   title: string;
   description: string;
   date: string;
@@ -125,7 +126,9 @@ export function buildPublishableFiles(input: {
   body: string;
   coverName: string;
   coverDataUrl: string;
-}): BuildResult {
+};
+
+export function buildPublishableFiles(input: PublishInput): BuildResult {
   const parsed = blogDraftSchema.safeParse({
     title: input.title,
     description: input.description,

--- a/src/lib/blogMarkdown.ts
+++ b/src/lib/blogMarkdown.ts
@@ -88,14 +88,25 @@ export function coverFromDataUrl(
   fileName: string,
   dataUrl: string,
 ): CoverImage | null {
-  const match = /^data:([^;,]+)?(?:;[^,]*)*,(.*)$/s.exec(dataUrl);
-  if (!match) return null;
+  // Parsed by slicing rather than by regex on purpose: the obvious pattern
+  // for a data URL header (`(?:;[^,]*)*`) is ambiguous and backtracks
+  // exponentially on a header full of semicolons. Splitting at the first
+  // comma is linear and, being the actual definition of the format, also
+  // says what it means.
+  if (!dataUrl.startsWith("data:")) return null;
+  const separator = dataUrl.indexOf(",");
+  if (separator < 0) return null;
 
-  const [, mime = "", payload = ""] = match;
-  const extension =
-    /\.([a-z0-9]+)$/i.exec(fileName)?.[1]?.toLowerCase() ??
-    mime.split("/")[1] ??
-    "png";
+  const header = dataUrl.slice("data:".length, separator);
+  const payload = dataUrl.slice(separator + 1);
+  // `image/png;base64` → `image/png`; the parameters after it don't matter.
+  const mime = header.split(";")[0] ?? "";
+
+  const rawExtension =
+    /\.([a-z0-9]+)$/i.exec(fileName)?.[1] ?? mime.split("/")[1] ?? "png";
+  // A subtype is not always a usable extension: `image/svg+xml` would give
+  // `svg+xml`, and that plus sign has no business in a committed filename.
+  const extension = rawExtension.toLowerCase().replace(/[^a-z0-9]/g, "") || "png";
 
   return { name: `${slug}.${extension}`, base64: payload };
 }

--- a/src/lib/blogMarkdown.ts
+++ b/src/lib/blogMarkdown.ts
@@ -1,0 +1,146 @@
+import { blogDraftSchema, type BlogDraftValues } from "@/lib/blogSchema";
+
+/**
+ * Serialising a draft into the exact file the repository expects: YAML
+ * frontmatter followed by the markdown body, matching the style of the
+ * posts already in `src/content/blog`.
+ */
+
+/** Where a post's markdown file lives, relative to the repo root. */
+export const BLOG_CONTENT_DIR = "src/content/blog";
+
+/**
+ * YAML scalars only need quoting in a handful of cases. Titles and
+ * descriptions routinely contain colons ("Effect Schema: a tour"), which is
+ * exactly one of them, so quote whenever the value could be misread and
+ * escape the quotes inside.
+ */
+function yamlScalar(value: string): string {
+  const trimmed = value.trim();
+  const needsQuotes =
+    trimmed === "" ||
+    /^[-?:,[\]{}#&*!|>'"%@`]/.test(trimmed) ||
+    /:\s/.test(trimmed) ||
+    /\s#/.test(trimmed) ||
+    /[\n\r]/.test(trimmed) ||
+    /^(true|false|null|yes|no|on|off|~)$/i.test(trimmed) ||
+    /^[\d.+-]+$/.test(trimmed);
+
+  if (!needsQuotes) return trimmed;
+  return `"${trimmed.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, " ")}"`;
+}
+
+export type PostFile = {
+  /** Repo-relative path of the markdown file. */
+  path: string;
+  /** Full file contents, frontmatter included. */
+  content: string;
+};
+
+export type CoverImage = {
+  /** File name as committed next to the markdown, e.g. `my-post.png`. */
+  name: string;
+  /** Base64 payload, without the `data:` prefix. */
+  base64: string;
+};
+
+/**
+ * Builds the markdown file for a draft. `coverName`, when given, is written
+ * as a relative `image:` reference — that is what Astro's `image()` helper
+ * resolves against the markdown file's own directory.
+ */
+export function buildPostFile(
+  draft: BlogDraftValues,
+  coverName?: string,
+): PostFile {
+  const lines = [
+    "---",
+    `title: ${yamlScalar(draft.title)}`,
+    `description: ${yamlScalar(draft.description)}`,
+  ];
+
+  if (coverName) lines.push(`image: ./${coverName}`);
+
+  lines.push(`date: ${toISODate(draft.date)}`, "tags:");
+  for (const tag of draft.tags) lines.push(`  - ${yamlScalar(tag)}`);
+  lines.push("---", "");
+
+  // Exactly one trailing newline, whatever the editor buffer ended with.
+  lines.push(`${draft.body.trim()}\n`);
+
+  return {
+    path: `${BLOG_CONTENT_DIR}/${draft.slug}.md`,
+    content: lines.join("\n"),
+  };
+}
+
+function toISODate(date: Date): string {
+  const offset = date.getTimezoneOffset() * 60_000;
+  return new Date(date.getTime() - offset).toISOString().slice(0, 10);
+}
+
+/**
+ * Splits a `data:` URL into the parts the GitHub API wants: a file name
+ * carrying the right extension and the raw base64 payload.
+ */
+export function coverFromDataUrl(
+  slug: string,
+  fileName: string,
+  dataUrl: string,
+): CoverImage | null {
+  const match = /^data:([^;,]+)?(?:;[^,]*)*,(.*)$/s.exec(dataUrl);
+  if (!match) return null;
+
+  const [, mime = "", payload = ""] = match;
+  const extension =
+    /\.([a-z0-9]+)$/i.exec(fileName)?.[1]?.toLowerCase() ??
+    mime.split("/")[1] ??
+    "png";
+
+  return { name: `${slug}.${extension}`, base64: payload };
+}
+
+/** Validates a draft and, when valid, produces the files to commit. */
+export type BuildResult =
+  | { ok: true; post: PostFile; cover: CoverImage | null }
+  | { ok: false; errors: string[] };
+
+export function buildPublishableFiles(input: {
+  title: string;
+  description: string;
+  date: string;
+  tags: string[];
+  slug: string;
+  body: string;
+  coverName: string;
+  coverDataUrl: string;
+}): BuildResult {
+  const parsed = blogDraftSchema.safeParse({
+    title: input.title,
+    description: input.description,
+    // The date arrives as `yyyy-mm-dd`; parsing it at midday sidesteps the
+    // timezone shift that would otherwise move it to the previous day.
+    date: input.date ? new Date(`${input.date}T12:00:00`) : new Date(Number.NaN),
+    tags: input.tags,
+    slug: input.slug,
+    body: input.body,
+  });
+
+  if (!parsed.success) {
+    return {
+      ok: false,
+      errors: parsed.error.issues.map((issue) => issue.message),
+    };
+  }
+
+  const cover =
+    input.coverDataUrl && input.coverName
+      ? coverFromDataUrl(parsed.data.slug, input.coverName, input.coverDataUrl)
+      : null;
+
+  return {
+    ok: true,
+    post: buildPostFile(parsed.data, cover?.name),
+    cover,
+  };
+}

--- a/src/lib/blogSchema.ts
+++ b/src/lib/blogSchema.ts
@@ -1,0 +1,44 @@
+import { z } from "astro/zod";
+
+/**
+ * Frontmatter fields of the `blog` collection, minus `image`.
+ *
+ * `image` lives in `src/content.config.ts` because it needs Astro's
+ * `image()` helper, which only exists at build time. Everything else is
+ * plain zod, so it is shared verbatim between the content collection and
+ * the client-side editor (`/blog/new`) — the editor validates a draft
+ * against the very same rules the build will apply to the committed file.
+ */
+export const blogFrontmatterFields = {
+  title: z.string(),
+  description: z.string(),
+  date: z.date(),
+  tags: z.array(z.string()),
+};
+
+/**
+ * What the editor enforces before letting a draft be published. Same
+ * fields as above, but non-empty: the collection schema accepts an empty
+ * title, a post with one would just be useless.
+ */
+export const blogDraftSchema = z.object({
+  title: z.string().trim().min(1, "El título es obligatorio"),
+  description: z
+    .string()
+    .trim()
+    .min(1, "La descripción es obligatoria (se usa en las tarjetas y en el SEO)"),
+  date: z.date({ error: "La fecha no es válida" }),
+  tags: z.array(z.string().trim().min(1)).min(1, "Añade al menos una etiqueta"),
+  slug: z
+    .string()
+    .trim()
+    .min(1, "El slug es obligatorio")
+    .regex(
+      /^[a-z0-9]+(?:-[a-z0-9]+)*$/,
+      "El slug sólo admite minúsculas, números y guiones",
+    ),
+  body: z.string().trim().min(1, "El cuerpo del artículo está vacío"),
+});
+
+export type BlogDraftInput = z.input<typeof blogDraftSchema>;
+export type BlogDraftValues = z.output<typeof blogDraftSchema>;

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -1,0 +1,224 @@
+import type { CoverImage, PostFile } from "@/lib/blogMarkdown";
+
+/**
+ * Client-side publishing to GitHub. Two routes, because they trade off
+ * differently and both are worth having:
+ *
+ *  - `openPrefilledEditor` needs no credentials at all: it hands GitHub's
+ *    own "create new file" screen a filename and a body, and the user
+ *    commits from there. Limited by URL length and cannot carry a binary.
+ *  - `publishViaApi` needs a fine-grained token with Contents +
+ *    Pull requests write, and does the whole branch → commit → PR dance
+ *    from the browser.
+ *
+ * There is no server involved in either.
+ */
+
+export const REPO_OWNER = "danielo515";
+export const REPO_NAME = "danielo515.github.io";
+export const REPO_BASE_BRANCH = "astro";
+
+const API_ROOT = "https://api.github.com";
+
+/**
+ * Browsers vary, but every one of them gives up somewhere around 32k of
+ * URL. Staying well under keeps the prefilled route predictable.
+ */
+export const PREFILL_URL_LIMIT = 6000;
+
+export type RepoTarget = {
+  owner: string;
+  repo: string;
+  baseBranch: string;
+};
+
+export const DEFAULT_TARGET: RepoTarget = {
+  owner: REPO_OWNER,
+  repo: REPO_NAME,
+  baseBranch: REPO_BASE_BRANCH,
+};
+
+/**
+ * GitHub's new-file editor accepts `filename` and `value` query params and
+ * pre-fills the form with them. Committing from that screen offers "create
+ * a new branch and start a pull request", which is the PR interface we are
+ * after — without ever holding a token.
+ */
+export function prefilledEditorUrl(target: RepoTarget, post: PostFile): string {
+  const params = new URLSearchParams({
+    filename: post.path,
+    value: post.content,
+  });
+  return `https://github.com/${target.owner}/${target.repo}/new/${target.baseBranch}?${params}`;
+}
+
+export function prefillFitsInUrl(target: RepoTarget, post: PostFile): boolean {
+  return prefilledEditorUrl(target, post).length <= PREFILL_URL_LIMIT;
+}
+
+// ─── TOKEN-BASED PUBLISHING ──────────────────────────────────────────────────
+
+export class GitHubError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+  ) {
+    super(message);
+    this.name = "GitHubError";
+  }
+}
+
+async function api<T>(
+  token: string,
+  path: string,
+  init?: { method?: string; body?: unknown },
+): Promise<T> {
+  const response = await fetch(`${API_ROOT}${path}`, {
+    method: init?.method ?? "GET",
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${token}`,
+      "X-GitHub-Api-Version": "2022-11-28",
+      ...(init?.body ? { "Content-Type": "application/json" } : {}),
+    },
+    body: init?.body ? JSON.stringify(init.body) : undefined,
+  });
+
+  if (!response.ok) {
+    const detail = await response
+      .json()
+      .then((body: { message?: string }) => body.message)
+      .catch(() => null);
+    throw new GitHubError(
+      detail ?? `GitHub respondió ${response.status}`,
+      response.status,
+    );
+  }
+
+  return response.json() as Promise<T>;
+}
+
+export type PublishRequest = {
+  token: string;
+  target: RepoTarget;
+  post: PostFile;
+  cover: CoverImage | null;
+  branch: string;
+  commitMessage: string;
+  prTitle: string;
+  prBody: string;
+};
+
+export type PublishResult = {
+  prUrl: string;
+  prNumber: number;
+  branch: string;
+};
+
+/**
+ * Creates a branch, commits the post (plus its cover, when there is one) as
+ * a single commit via the git data API, and opens the pull request.
+ */
+export async function publishViaApi(
+  request: PublishRequest,
+): Promise<PublishResult> {
+  const { token, target, post, cover, branch } = request;
+  const repoPath = `/repos/${target.owner}/${target.repo}`;
+
+  const baseRef = await api<{ object: { sha: string } }>(
+    token,
+    `${repoPath}/git/ref/heads/${target.baseBranch}`,
+  );
+  const baseCommitSha = baseRef.object.sha;
+
+  const baseCommit = await api<{ tree: { sha: string } }>(
+    token,
+    `${repoPath}/git/commits/${baseCommitSha}`,
+  );
+
+  await api(token, `${repoPath}/git/refs`, {
+    method: "POST",
+    body: { ref: `refs/heads/${branch}`, sha: baseCommitSha },
+  });
+
+  // One blob per file. The markdown goes as utf-8; the cover has to be
+  // base64 because it is binary.
+  const treeEntries: Array<{
+    path: string;
+    mode: "100644";
+    type: "blob";
+    sha: string;
+  }> = [];
+
+  const postBlob = await api<{ sha: string }>(token, `${repoPath}/git/blobs`, {
+    method: "POST",
+    body: { content: post.content, encoding: "utf-8" },
+  });
+  treeEntries.push({
+    path: post.path,
+    mode: "100644",
+    type: "blob",
+    sha: postBlob.sha,
+  });
+
+  if (cover) {
+    const coverBlob = await api<{ sha: string }>(
+      token,
+      `${repoPath}/git/blobs`,
+      { method: "POST", body: { content: cover.base64, encoding: "base64" } },
+    );
+    treeEntries.push({
+      path: `${post.path.replace(/\/[^/]+$/, "")}/${cover.name}`,
+      mode: "100644",
+      type: "blob",
+      sha: coverBlob.sha,
+    });
+  }
+
+  const tree = await api<{ sha: string }>(token, `${repoPath}/git/trees`, {
+    method: "POST",
+    body: { base_tree: baseCommit.tree.sha, tree: treeEntries },
+  });
+
+  const commit = await api<{ sha: string }>(token, `${repoPath}/git/commits`, {
+    method: "POST",
+    body: {
+      message: request.commitMessage,
+      tree: tree.sha,
+      parents: [baseCommitSha],
+    },
+  });
+
+  await api(token, `${repoPath}/git/refs/heads/${branch}`, {
+    method: "PATCH",
+    body: { sha: commit.sha },
+  });
+
+  const pr = await api<{ html_url: string; number: number }>(
+    token,
+    `${repoPath}/pulls`,
+    {
+      method: "POST",
+      body: {
+        title: request.prTitle,
+        body: request.prBody,
+        head: branch,
+        base: target.baseBranch,
+      },
+    },
+  );
+
+  return { prUrl: pr.html_url, prNumber: pr.number, branch };
+}
+
+/**
+ * Branch names are derived from the slug. The suffix keeps a second attempt
+ * at the same post from colliding with the branch left behind by the first.
+ */
+export function branchNameFor(slug: string): string {
+  const stamp = new Date()
+    .toISOString()
+    .replace(/[-:T]/g, "")
+    .slice(0, 12);
+  return `post/${slug}-${stamp}`;
+}

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -1,4 +1,9 @@
-import type { CoverImage, PostFile } from "@/lib/blogMarkdown";
+import {
+  buildPublishableFiles,
+  type CoverImage,
+  type PostFile,
+  type PublishInput,
+} from "@/lib/blogMarkdown";
 
 /**
  * Client-side publishing to GitHub. Two routes, because they trade off
@@ -52,8 +57,59 @@ export function prefilledEditorUrl(target: RepoTarget, post: PostFile): string {
   return `https://github.com/${target.owner}/${target.repo}/new/${target.baseBranch}?${params}`;
 }
 
-export function prefillFitsInUrl(target: RepoTarget, post: PostFile): boolean {
-  return prefilledEditorUrl(target, post).length <= PREFILL_URL_LIMIT;
+export type PrefillOverflow = {
+  /** Characters to delete from the article for the URL to fit. */
+  bodyExcess: number;
+};
+
+/**
+ * How much of the article has to go for the prefilled URL to fit — `null`
+ * when it already does.
+ *
+ * Answered by rebuilding the real file and measuring the real URL, not by
+ * costing characters: percent-encoding inflates by a different factor per
+ * character, and `buildPostFile` trims the body, so a deleted trailing
+ * newline shrinks the article without shrinking the URL. Modelling that
+ * left the advice a couple of characters short, which is exactly the
+ * "guess again" loop the number is meant to end. Removing more text can
+ * never lengthen the URL, so a binary search over how much to keep finds
+ * the tight answer.
+ */
+export function prefillOverflow(
+  target: RepoTarget,
+  draft: PublishInput,
+): PrefillOverflow | null {
+  const fits = (body: string) => {
+    const built = buildPublishableFiles({ ...draft, body });
+    return (
+      built.ok && prefilledEditorUrl(target, built.post).length <= PREFILL_URL_LIMIT
+    );
+  };
+
+  if (fits(draft.body)) return null;
+
+  const characters = [...draft.body];
+  const keep = (count: number) => characters.slice(0, count).join("");
+
+  // Largest prefix that still fits. Starts at 1 because the schema rejects
+  // an empty body, so a zero-length prefix could never "fit" anyway.
+  let low = 1;
+  let high = characters.length;
+  let best = 0;
+  while (low <= high) {
+    const middle = Math.floor((low + high) / 2);
+    if (fits(keep(middle))) {
+      best = middle;
+      low = middle + 1;
+    } else {
+      high = middle - 1;
+    }
+  }
+
+  // `best === 0` means even a one-character article overflows — only
+  // reachable with an absurdly long title or slug, and cutting prose is
+  // still the direction of travel.
+  return { bodyExcess: characters.length - best };
 }
 
 // ─── TOKEN-BASED PUBLISHING ──────────────────────────────────────────────────

--- a/src/pages/blog/new.astro
+++ b/src/pages/blog/new.astro
@@ -1,0 +1,37 @@
+---
+import BlogEditorApp from "@/components/BlogEditor/BlogEditorApp";
+import SectionContainer from "@/components/SectionContainer.astro";
+import Layout from "@/layouts/Layout.astro";
+import { getCollection } from "astro:content";
+import { config } from "./config";
+
+// Tags already in use across the blog, offered as suggestions so the new
+// entry reuses the existing vocabulary instead of inventing synonyms.
+const posts = await getCollection("blog");
+const tagSuggestions = [
+  ...new Set(posts.flatMap((post) => post.data.tags)),
+].sort();
+---
+
+<Layout
+  title="Nueva entrada del blog"
+  description="Editor de entradas del blog"
+  footerLinks={config.footerLinks}
+  navItems={config.navItems}
+>
+  <main class="px-4">
+    <SectionContainer class="py-12 md:py-20">
+      <header class="mb-8">
+        <h1 class="text-3xl font-bold text-gray-800 dark:text-white mb-2">
+          Nueva entrada
+        </h1>
+        <p class="text-sm text-gray-600 dark:text-gray-400">
+          Editor 100% en el navegador. Los borradores se guardan solos y, al
+          publicar, se abre una pull request contra el repositorio.
+        </p>
+      </header>
+
+      <BlogEditorApp tagSuggestions={tagSuggestions} client:only="react" />
+    </SectionContainer>
+  </main>
+</Layout>


### PR DESCRIPTION
Un editor para escribir entradas nuevas del blog en `/blog/new`, que funciona entero en el navegador y termina abriendo una pull request.

## Qué hace

**Nada de backend propio.** La página es estática; todo ocurre en el cliente.

**Los borradores no se pierden.** El estado del editor vive en Jazz (CoValues), no en React: cada tecla queda guardada, así que recargar, cerrar la pestaña o cerrar el portátil no se lleva el texto por delante. El panel de sincronización usa el mismo flujo de frase de recuperación que el workout tracker, de modo que los borradores también viajan entre dispositivos. Verificado en navegador: escribir → recargar → el título, el cuerpo y las etiquetas siguen ahí.

**Respeta el esquema del blog.** Los campos del frontmatter (menos `image`, que necesita el helper `image()` de Astro y sólo existe en build) se extraen a `@/lib/blogSchema` y los consumen tanto `src/content.config.ts` como el editor. El editor valida contra el mismo esquema que aplicará el build, y no deja publicar hasta que el borrador pasa.

**Publicar abre una PR**, por dos caminos según lo que tengas a mano:

| | Con token fine-grained | Sin token |
|---|---|---|
| Qué hace | Crea rama, commit y PR contra `astro` desde el navegador | Abre el editor de GitHub con el artículo ya escrito |
| Portada | Se sube en el mismo commit | No (hay que añadirla a mano) |
| Artículos largos | Sin límite | Puede no caber en la URL; avisa cuando pasa |

El token se guarda sólo en el `localStorage` de ese dispositivo y **nunca** entra en Jazz: sincroniza a un peer compartido y una credencial con permiso de escritura sobre el repo no pinta nada ahí.

## Además

Vista previa del markdown, slug derivado del título (sin acentos ni signos) y editable a mano, sugerencias con las etiquetas ya usadas en el blog, portada opcional y descarga del `.md` como salida de emergencia.

## Comprobaciones

- `pnpm run check` — 0 errores.
- `pnpm run build` — 24 páginas.
- Recorrido real en Chromium: crear borrador, rellenarlo, previsualizar, recargar y comprobar que persiste. Sin errores en consola.
- El `.md` generado se metió en `src/content/blog/` y el build lo aceptó y renderizó como entrada real — es decir, la salida del editor pasa el esquema de la colección de verdad, no sólo la copia del cliente. El fichero de prueba se borró después.
- Los dos puntos y las comillas en título y descripción salen correctamente escapados en el YAML.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DntJf3e5mkBgRp9oGxqdQz)_