### PR TITLE
Add oxlint and Effect language service checks to every pull request

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,64 @@
+name: CI
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  oxlint:
+    name: oxlint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 10.33.0
+          run_install: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "pnpm"
+          cache-dependency-path: "./pnpm-lock.yaml"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Run oxlint
+        run: pnpm exec oxlint --deny-warnings --format github
+
+  effect-language-service:
+    name: Effect language service diagnostics
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 10.33.0
+          run_install: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "pnpm"
+          cache-dependency-path: "./pnpm-lock.yaml"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Run Effect diagnostics
+        run: pnpm exec effect-language-service diagnostics --project tsconfig.json --strict --format github-actions

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -24,23 +24,6 @@
       "env": {
         "node": true
       }
-    },
-    {
-      "files": [
-        "src/components/CVLink.tsx",
-        "src/components/EchoAura.tsx",
-        "src/components/EchoEqualizer.tsx",
-        "src/components/Workout/WorkoutApp.tsx",
-        "src/pages/tools/echo.tsx",
-        "src/pages/tools/image-to-bmp.tsx",
-        "src/pages/tools/token-calculator.tsx"
-      ],
-      "rules": {
-        "react/refs": "off",
-        "react/immutability": "off",
-        "react/set-state-in-effect": "off",
-        "react-hooks/exhaustive-deps": "off"
-      }
     }
   ]
 }

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "./node_modules/oxlint/configuration_schema.json",
+  "plugins": ["typescript", "react", "unicorn", "oxc"],
+  "categories": {
+    "correctness": "warn"
+  },
+  "env": {
+    "browser": true,
+    "es2022": true
+  },
+  "rules": {
+    "react/react-in-jsx-scope": "off"
+  },
+  "ignorePatterns": ["dist", ".astro", "node_modules", "public"],
+  "overrides": [
+    {
+      "files": ["src/env.d.ts"],
+      "rules": {
+        "typescript/triple-slash-reference": "off"
+      }
+    },
+    {
+      "files": ["scripts/**", "astro.config.mjs"],
+      "env": {
+        "node": true
+      }
+    },
+    {
+      "files": [
+        "src/components/CVLink.tsx",
+        "src/components/EchoAura.tsx",
+        "src/components/EchoEqualizer.tsx",
+        "src/components/Workout/WorkoutApp.tsx",
+        "src/pages/tools/echo.tsx",
+        "src/pages/tools/image-to-bmp.tsx",
+        "src/pages/tools/token-calculator.tsx"
+      ],
+      "rules": {
+        "react/refs": "off",
+        "react/immutability": "off",
+        "react/set-state-in-effect": "off",
+        "react-hooks/exhaustive-deps": "off"
+      }
+    }
+  ]
+}

--- a/Agents.md
+++ b/Agents.md
@@ -21,6 +21,8 @@ pnpm run dev          # Start development server
 pnpm run build        # Build with TypeScript check
 pnpm run check        # Run TypeScript check only
 pnpm run preview      # Build and preview production
+pnpm run lint         # Run oxlint (warnings fail the run)
+pnpm run lint:effect  # Run Effect language service diagnostics
 ```
 
 ### Adding Dependencies
@@ -126,9 +128,10 @@ Configured in `tsconfig.json`:
 Before considering any task complete, you **MUST** run the following checks:
 
 1. **Type Check**: Run `pnpm run check` to verify there are no TypeScript errors
-2. **Build**: Run `pnpm run build` to ensure the project builds successfully
+2. **Lint**: Run `pnpm run lint` (oxlint) and `pnpm run lint:effect` (Effect language service diagnostics)
+3. **Build**: Run `pnpm run build` to ensure the project builds successfully
 
-Both commands must pass without errors before committing or marking a task as done. If either fails, fix the issues before proceeding.
+All commands must pass without errors before committing or marking a task as done. If any fails, fix the issues before proceeding. The lint checks also run in CI on every pull request (`.github/workflows/ci.yaml`).
 
 ## Git Commit Messages
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "check": "astro check",
     "preview": "astro build && astro preview",
     "astro": "astro",
+    "lint": "oxlint --deny-warnings",
+    "lint:effect": "effect-language-service diagnostics --project tsconfig.json --strict",
     "generate-pdf": "node scripts/generate-cv-pdf.mjs",
     "build:with-pdf": "astro check && astro build && node scripts/generate-cv-pdf.mjs"
   },
@@ -34,9 +36,11 @@
     "typescript": "5.9.3"
   },
   "devDependencies": {
+    "@effect/language-service": "^0.87.2",
     "@tailwindcss/typography": "^0.5.15",
     "@types/node": "^24.0.7",
     "@webgpu/types": "^0.1.70",
+    "oxlint": "^1.79.0",
     "playwright": "^1.55.1"
   },
   "pnpm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
         specifier: 5.9.3
         version: 5.9.3
     devDependencies:
+      '@effect/language-service':
+        specifier: ^0.87.2
+        version: 0.87.2
       '@tailwindcss/typography':
         specifier: ^0.5.15
         version: 0.5.16(tailwindcss@4.1.18)
@@ -75,6 +78,9 @@ importers:
       '@webgpu/types':
         specifier: ^0.1.70
         version: 0.1.70
+      oxlint:
+        specifier: ^1.79.0
+        version: 1.79.0
       playwright:
         specifier: ^1.55.1
         version: 1.55.1
@@ -231,6 +237,10 @@ packages:
   '@ctrl/tinycolor@4.2.0':
     resolution: {integrity: sha512-kzyuwOAQnXJNLS9PSyrk0CWk35nWJW/zl/6KvnTBMFK65gm7U1/Z5BqjxeapjZCIhQcM/DsrEmcbRwDyXyXK4A==}
     engines: {node: '>=14'}
+
+  '@effect/language-service@0.87.2':
+    resolution: {integrity: sha512-CfiSoaVQO8pZgaMZGw5VvMvRGybsJ2LaSDoLYaqiVGvo/YYPYVR2GzUKY0h1NtIweq/+SQ5XLrvtzPIttWQ0GQ==}
+    hasBin: true
 
   '@emmetio/abbreviation@2.3.3':
     resolution: {integrity: sha512-mgv58UrU3rh4YgbE/TzgLQwJ3pFsHHhCLqY20aJq+9comytTXUDNGG/SMtSeMJdkpxgXSXunBGLD8Boka3JyVA==}
@@ -625,6 +635,128 @@ packages:
 
   '@oslojs/encoding@1.1.0':
     resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
+
+  '@oxlint/binding-android-arm-eabi@1.79.0':
+    resolution: {integrity: sha512-TebFaaMklO/RXzTv7PucaCq9l3X6D1gA+C8H6K4njtjFOV+zWE9MKLpulcJZN9bzytbUbQIY0mZuz12nQ5Kv4Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxlint/binding-android-arm64@1.79.0':
+    resolution: {integrity: sha512-KqqnOtAVgNsPPF0YSodkFZA1O80jcKoCZCTu3bgsszxA+MrMP9TLzfXitKjEj1FmrPprKDMdRDMmY3weESO9sg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxlint/binding-darwin-arm64@1.79.0':
+    resolution: {integrity: sha512-BVC2nsMzqQzRDPc5RhixkZ+m1p7iH4bxRRvqkbwDXX0PlQKm1BPy8J8cRjnAFafOq2QzI+BfO3vE8w2GZ3CBag==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxlint/binding-darwin-x64@1.79.0':
+    resolution: {integrity: sha512-p6Lm+snmhGuLKL1+CpCV8L6ijkE/qJzK2H2jG9+eKJT0n31RbY4FLsdhexekgP3bLpw4Kgde+9DZuDZQ4yIInA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxlint/binding-freebsd-x64@1.79.0':
+    resolution: {integrity: sha512-qDMm0dXZnoHyRqSL4N4xUq82T4sqK5cbKSjvd/dF/YbMUXc2R1wEPf+vmA5S0qUmi0nwXfNbjXBtZaIqzQLIMg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxlint/binding-linux-arm-gnueabihf@1.79.0':
+    resolution: {integrity: sha512-2od7s0nuKPzqyUZAWk9KkCyGg7eI9dwFPZg+20lB15fKFkVZ0c9ZFxqPfiBAyDTlTkh9stPI0t+JlPCqMbItVA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm-musleabihf@1.79.0':
+    resolution: {integrity: sha512-ZOQUjkzDnvlhSE3+tWC3YXx94MMl+sYMlwH+u1+YGApGHOJP/YAc8ZBRFOXZ6eOBmxtXAWuS/fBcdZr8qqNO1A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm64-gnu@1.79.0':
+    resolution: {integrity: sha512-lu158FR4nGqGeRS3BQvtG85wRgU/Fy4MD5Cxp1hzJXizGiLo6u2742wJSCDKh8cFcZntvX7fcxlq4mMmfryH1g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-arm64-musl@1.79.0':
+    resolution: {integrity: sha512-mbpKQeE2aflTjddaHK7MP8KP/OFbUM++lt5M635ENM8IyIdK0jm2t9pb+2v9mVVIvhF6TqA4l7F79Pll1mi+uw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxlint/binding-linux-ppc64-gnu@1.79.0':
+    resolution: {integrity: sha512-WpGNua7gaxaHnpSDeog2ji8IDHn/QLPl9LPzwkR/FvVv58vT5BcXjRXnU+wbu3N75cpeha8CdC7ho/U2OIsB4g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-riscv64-gnu@1.79.0':
+    resolution: {integrity: sha512-tK1E93A5LVzISg4ngpKJnfTs7EqtIUceGI7MQ4GyDjJiLi8wPCkEyKlj2xkyKWZ1yzkDJyLHTBJ5/iFWRdnJvg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-riscv64-musl@1.79.0':
+    resolution: {integrity: sha512-qhQvUIrngXivA2A9pQ+xPCychztn/5qUv7yS3gDwXv3w7Rag+eTeeXWmRyx+t7XsW5x6LuY/8AsTq36UgFIblg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxlint/binding-linux-s390x-gnu@1.79.0':
+    resolution: {integrity: sha512-sv6AaVgU/eE6u+6WFiQVDcPPwTxP6IJMSB9k701W2r/r6Tx465e8vPvVyRxquNH4Vy6KwRNu90mVbxXJN8+5gg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-x64-gnu@1.79.0':
+    resolution: {integrity: sha512-iFZL02deziHslb3jEX9KdqlAkYoo4fGyotchKDzdfK1f5mxlIBeiQeHhvK3iFpuEJSB4ma/qeFn9oxPiwnhUPQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-x64-musl@1.79.0':
+    resolution: {integrity: sha512-3DtZR2raqObnh7wXZoFYFd0Fw7skBvcb3f7A+/lkEiDuh8hrE6vv9b/62Qxao1a9/OeHLw/FcXlXzgsW9wTRFg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxlint/binding-openharmony-arm64@1.79.0':
+    resolution: {integrity: sha512-Oatt4GuA1WJkqzk2ozx4HrWROOi7opV3AKDw/U8qDIqeTqzsjn5K2x3REJMNjU3/KU/Bkq96Zi3CknaiDTaC/Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxlint/binding-win32-arm64-msvc@1.79.0':
+    resolution: {integrity: sha512-NAgZr9Qp8nIA9rpo0JEvwiabTF/2UVqBNnupBG9X4kxXcQoScJUTi+qHhvabb9s/thgj5wQ4XcIaJvb+ZMgoKw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxlint/binding-win32-ia32-msvc@1.79.0':
+    resolution: {integrity: sha512-+KyXjIvcpaXmWW/j9NNY5yWjrIVxaX18VyIheQy3jwc2GSYgpCr7MGI/HxIGQ/shAL5IWEKbhsqoMpAO5Stiog==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxlint/binding-win32-x64-msvc@1.79.0':
+    resolution: {integrity: sha512-mEelcCMMBS57sIXh2veGMNy+pQwuGtcMxHxGIZWQ5Ba9pJ5jCCUFOZB9E2JhBaxGsURe+WGe0zJp4RVre52gpQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
 
   '@react-native/assets-registry@0.85.3':
     resolution: {integrity: sha512-u9ZiYP23vA2IFtdFQFmetzSmk6SM0xgKIoiOsr1hXNHjHaLhOm+/Ph1ud57wX6+Dbwdzx8coJgnzSKL3W21PCg==}
@@ -2348,6 +2480,19 @@ packages:
   orderedmap@2.1.1:
     resolution: {integrity: sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==}
 
+  oxlint@1.79.0:
+    resolution: {integrity: sha512-hVJ9hq9m2unPS+Of4eJJgCPdIeCC+3DHEUX3tkmrPJr3OK2hz7PhXwgC+ZP71ZcYu8cCDEtQrqLxWNvxBppBVg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      oxlint-tsgolint: '>=7.0.2001'
+      vite-plus: '*'
+    peerDependenciesMeta:
+      oxlint-tsgolint:
+        optional: true
+      vite-plus:
+        optional: true
+
   p-limit@7.3.0:
     resolution: {integrity: sha512-7cIXg/Z0M5WZRblrsOla88S4wAK+zOQQWeBYfV3qJuJXMr+LnbYjaadrFaS0JILfEDPVqHyKnZ1Z/1d6J9VVUw==}
     engines: {node: '>=20'}
@@ -3461,6 +3606,8 @@ snapshots:
 
   '@ctrl/tinycolor@4.2.0': {}
 
+  '@effect/language-service@0.87.2': {}
+
   '@emmetio/abbreviation@2.3.3':
     dependencies:
       '@emmetio/scanner': 1.0.4
@@ -3736,6 +3883,63 @@ snapshots:
   '@opentelemetry/api@1.9.0': {}
 
   '@oslojs/encoding@1.1.0': {}
+
+  '@oxlint/binding-android-arm-eabi@1.79.0':
+    optional: true
+
+  '@oxlint/binding-android-arm64@1.79.0':
+    optional: true
+
+  '@oxlint/binding-darwin-arm64@1.79.0':
+    optional: true
+
+  '@oxlint/binding-darwin-x64@1.79.0':
+    optional: true
+
+  '@oxlint/binding-freebsd-x64@1.79.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm-gnueabihf@1.79.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm-musleabihf@1.79.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm64-gnu@1.79.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm64-musl@1.79.0':
+    optional: true
+
+  '@oxlint/binding-linux-ppc64-gnu@1.79.0':
+    optional: true
+
+  '@oxlint/binding-linux-riscv64-gnu@1.79.0':
+    optional: true
+
+  '@oxlint/binding-linux-riscv64-musl@1.79.0':
+    optional: true
+
+  '@oxlint/binding-linux-s390x-gnu@1.79.0':
+    optional: true
+
+  '@oxlint/binding-linux-x64-gnu@1.79.0':
+    optional: true
+
+  '@oxlint/binding-linux-x64-musl@1.79.0':
+    optional: true
+
+  '@oxlint/binding-openharmony-arm64@1.79.0':
+    optional: true
+
+  '@oxlint/binding-win32-arm64-msvc@1.79.0':
+    optional: true
+
+  '@oxlint/binding-win32-ia32-msvc@1.79.0':
+    optional: true
+
+  '@oxlint/binding-win32-x64-msvc@1.79.0':
+    optional: true
 
   '@react-native/assets-registry@0.85.3': {}
 
@@ -5755,6 +5959,28 @@ snapshots:
       is-wsl: 2.2.0
 
   orderedmap@2.1.1: {}
+
+  oxlint@1.79.0:
+    optionalDependencies:
+      '@oxlint/binding-android-arm-eabi': 1.79.0
+      '@oxlint/binding-android-arm64': 1.79.0
+      '@oxlint/binding-darwin-arm64': 1.79.0
+      '@oxlint/binding-darwin-x64': 1.79.0
+      '@oxlint/binding-freebsd-x64': 1.79.0
+      '@oxlint/binding-linux-arm-gnueabihf': 1.79.0
+      '@oxlint/binding-linux-arm-musleabihf': 1.79.0
+      '@oxlint/binding-linux-arm64-gnu': 1.79.0
+      '@oxlint/binding-linux-arm64-musl': 1.79.0
+      '@oxlint/binding-linux-ppc64-gnu': 1.79.0
+      '@oxlint/binding-linux-riscv64-gnu': 1.79.0
+      '@oxlint/binding-linux-riscv64-musl': 1.79.0
+      '@oxlint/binding-linux-s390x-gnu': 1.79.0
+      '@oxlint/binding-linux-x64-gnu': 1.79.0
+      '@oxlint/binding-linux-x64-musl': 1.79.0
+      '@oxlint/binding-openharmony-arm64': 1.79.0
+      '@oxlint/binding-win32-arm64-msvc': 1.79.0
+      '@oxlint/binding-win32-ia32-msvc': 1.79.0
+      '@oxlint/binding-win32-x64-msvc': 1.79.0
 
   p-limit@7.3.0:
     dependencies:

--- a/src/components/CVLink.tsx
+++ b/src/components/CVLink.tsx
@@ -31,6 +31,7 @@ export default function CVLink({ children, hash, className }: CVLinkProps) {
   const [lang, setLang] = useState<SupportedLanguage>(DEFAULT_LANGUAGE);
 
   useEffect(() => {
+    // oxlint-disable-next-line react/set-state-in-effect -- TODO: reads a browser-only API (navigator.language), so it can't be derived during render/SSR; needs a restructure (e.g. lazy useState initializer guarded for SSR) to avoid the extra render.
     setLang(getBrowserLanguage());
   }, []);
 

--- a/src/components/EchoAura.tsx
+++ b/src/components/EchoAura.tsx
@@ -186,7 +186,9 @@ export default function EchoAura({ freqDataRef, hue, active }: Props) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const hueRef = useRef(hue);
   const activeRef = useRef(active ? 1 : 0);
+  // oxlint-disable-next-line react/refs -- TODO: written during render to keep the rAF draw loop in sync; move to a useEffect/useLayoutEffect.
   hueRef.current = hue;
+  // oxlint-disable-next-line react/refs -- TODO: written during render to keep the rAF draw loop in sync; move to a useEffect/useLayoutEffect.
   activeRef.current = active ? 1 : 0;
 
   useEffect(() => {

--- a/src/components/EchoEqualizer.tsx
+++ b/src/components/EchoEqualizer.tsx
@@ -165,7 +165,9 @@ export default function EchoEqualizer({ freqDataRef, hue, active }: Props) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const hueRef = useRef(hue);
   const activeRef = useRef(active ? 1 : 0);
+  // oxlint-disable-next-line react/refs -- TODO: written during render to keep the rAF draw loop in sync; move to a useEffect/useLayoutEffect.
   hueRef.current = hue;
+  // oxlint-disable-next-line react/refs -- TODO: written during render to keep the rAF draw loop in sync; move to a useEffect/useLayoutEffect.
   activeRef.current = active ? 1 : 0;
 
   useEffect(() => {

--- a/src/components/Workout/WorkoutApp.tsx
+++ b/src/components/Workout/WorkoutApp.tsx
@@ -1104,6 +1104,7 @@ function useRestTimer() {
       return;
     }
     setSecondsLeft(remaining);
+    // oxlint-disable-next-line react/immutability -- TODO: `tick` is read while still initializing; use a named function expression instead of self-referencing the const.
     rafRef.current = requestAnimationFrame(tick);
   }, [finish]);
 
@@ -1186,6 +1187,7 @@ function useExerciseTimer() {
       return;
     }
     setSecondsLeft(remaining);
+    // oxlint-disable-next-line react/immutability -- TODO: `tick` is read while still initializing; use a named function expression instead of self-referencing the const.
     rafRef.current = requestAnimationFrame(tick);
   }, [finish]);
 

--- a/src/pages/tools/echo.tsx
+++ b/src/pages/tools/echo.tsx
@@ -327,13 +327,17 @@ export default function EchoSimulator() {
   const character = CHARACTERS[characterIdx]!;
 
   const stateRef = useRef<EchoState>("idle");
+  // oxlint-disable-next-line react/refs -- TODO: written during render to keep callbacks in sync; move to a useEffect/useLayoutEffect.
   stateRef.current = state;
   const silenceSecondsRef = useRef<number>(silenceSeconds);
+  // oxlint-disable-next-line react/refs -- TODO: written during render to keep callbacks in sync; move to a useEffect/useLayoutEffect.
   silenceSecondsRef.current = silenceSeconds;
   const noiseGateRef = useRef<number>(NOISE_GATE_LEVELS[noiseGate]!);
+  // oxlint-disable-next-line react/refs -- TODO: written during render to keep callbacks in sync; move to a useEffect/useLayoutEffect.
   noiseGateRef.current =
     NOISE_GATE_LEVELS[noiseGate] ?? NOISE_GATE_LEVELS[DEFAULT_NOISE_GATE_INDEX]!;
   const characterRef = useRef<CharacterDef>(character);
+  // oxlint-disable-next-line react/refs -- TODO: written during render to keep callbacks in sync; move to a useEffect/useLayoutEffect.
   characterRef.current = character;
 
   const streamRef = useRef<MediaStream | null>(null);
@@ -518,6 +522,7 @@ export default function EchoSimulator() {
     const analyser = analyserRef.current;
     const buf = bufferRef.current;
     if (!analyser || !buf) {
+      // oxlint-disable-next-line react/immutability -- TODO: `tick` is read while still initializing; use a named function expression instead of self-referencing the const.
       rafRef.current = requestAnimationFrame(tick);
       return;
     }

--- a/src/pages/tools/image-to-bmp.tsx
+++ b/src/pages/tools/image-to-bmp.tsx
@@ -458,6 +458,7 @@ function DitherThumb({
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const pendingRef = useRef(false);
   const lastArgsRef = useRef({ mode, crop, dither });
+  // oxlint-disable-next-line react/refs -- TODO: written during render to keep the render-effect in sync; move to a useEffect/useLayoutEffect.
   lastArgsRef.current = { mode, crop, dither };
 
   useEffect(() => {
@@ -513,6 +514,7 @@ function DitherMainPreview({
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const pendingRef = useRef(false);
   const lastArgsRef = useRef({ mode, crop, dither });
+  // oxlint-disable-next-line react/refs -- TODO: written during render to keep the render-effect in sync; move to a useEffect/useLayoutEffect.
   lastArgsRef.current = { mode, crop, dither };
 
   useEffect(() => {

--- a/src/pages/tools/token-calculator.tsx
+++ b/src/pages/tools/token-calculator.tsx
@@ -73,7 +73,7 @@ export default function TokenCostCalculator() {
       // Ctrl/Cmd + N to add model
       if ((e.ctrlKey || e.metaKey) && e.key === "n") {
         e.preventDefault();
-        addPricing();
+        addPricing(); // oxlint-disable-line react/immutability -- TODO: `addPricing` is read while still initializing (declared below via useCallback); reorder declarations or use a ref.
       }
       // Ctrl/Cmd + D to toggle delete mode
       if ((e.ctrlKey || e.metaKey) && e.key === "d") {
@@ -89,6 +89,7 @@ export default function TokenCostCalculator() {
         const index = e.key.toLowerCase().charCodeAt(0) - 97;
         const visiblePricings = pricings.filter((p) => !p.deleted);
         if (index < visiblePricings.length && visiblePricings.length > 1) {
+          // oxlint-disable-next-line react/immutability -- TODO: `markAsDeleted` is read while still initializing (declared below via useCallback); reorder declarations or use a ref.
           markAsDeleted(visiblePricings[index]?.id ?? null);
           setDeleteMode(false);
         }
@@ -97,6 +98,7 @@ export default function TokenCostCalculator() {
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
+    // oxlint-disable-next-line react-hooks/exhaustive-deps -- TODO: closes over `addPricing`/`markAsDeleted`, declared below via useCallback, so they can't be listed as deps yet; reorder declarations or use refs.
   }, [deleteMode, pricings]);
 
   const addPricing = () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,11 @@
     "jsx": "react-jsx",
     "jsxImportSource": "react",
     "exactOptionalPropertyTypes": false,
-    "types": ["@webgpu/types"]
+    "types": ["@webgpu/types"],
+    "plugins": [
+      {
+        "name": "@effect/language-service"
+      }
+    ]
   }
 }


### PR DESCRIPTION
## Summary

Configures **oxlint** and the **Effect language service** for this repo and runs both on every pull request via a new CI workflow.

### oxlint
- Added `oxlint` as a dev dependency with an `.oxlintrc.json` config: correctness rules as the baseline, with the `typescript`, `react`, `unicorn`, and `oxc` plugins enabled.
- `react/react-in-jsx-scope` is off (the project uses the automatic JSX runtime), and Astro's conventional triple-slash reference in `src/env.d.ts` is exempted.
- A handful of pre-existing react-plugin findings (refs read during render in the canvas/animation components, self-referencing callbacks) are grandfathered per-file in the config so this PR stays a configuration change; new code gets the full rule set. The affected files are listed explicitly in `.oxlintrc.json` so the debt is visible and can be paid down later.
- New script: `pnpm run lint` (`oxlint --deny-warnings`, so warnings fail CI).

### Effect language service
- Added `@effect/language-service` as a dev dependency and registered it as a TypeScript plugin in `tsconfig.json`, so editors pick up Effect diagnostics, refactors and quickfixes (the existing `.vscode/settings.json` already points VS Code at the workspace TypeScript).
- New script: `pnpm run lint:effect` runs its CLI (`effect-language-service diagnostics --project tsconfig.json --strict`) for headless checking. The codebase has no Effect code yet, so it currently reports 0 diagnostics across 22 files — it will start reporting as soon as Effect code lands.

### CI
- New `.github/workflows/ci.yaml` triggered on `pull_request` with two jobs (oxlint and Effect diagnostics), mirroring the pnpm/Node 22 setup of the existing workflows. Both use GitHub annotation output formats so findings show inline on the PR diff.
- Documented the new commands in `Agents.md` and added them to the task completion requirements.

## Validation
- `pnpm run lint` — passes with 0 warnings (127 rules over 85 files)
- `pnpm run lint:effect` — passes, 0 diagnostics over 22 files
- `pnpm run check` — 0 errors
- `pnpm run build` — builds successfully (23 pages)